### PR TITLE
Emphasis APIM draft status, remove internal intro

### DIFF
--- a/content/guidance/apimanagement/index.html.md
+++ b/content/guidance/apimanagement/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: API Management Guidance
+title: DRAFT API Management Guidance
 weight: 830
 keywords: 'API Management'
 identifier: DSA-003
@@ -9,93 +9,14 @@ author_email: api-programme@digital.cabinet-office.gov.uk
 status: Draft
 startDate: 2021-03-22
 dateAdded: 2021-03-22
-dateUpdated: 2021-05-13
+dateUpdated: 2021-05-26
 ---
 
 
-## API Management Guidance | *DRAFT*
+## *DRAFT* | API Management Guidance | *DRAFT*
 
 
 _This is a DRAFT document for discussion. This is not finalised. All aspects of this document are subject to change. Please leave comments on any aspect of it._
-
-#### Contents:
-- [00 - Cover Page](index.html)
-- [01 - Introduction](APIM-Introduction.html)
-- [02 - Design](APIM-Design.html)
-- [03 - Deployment](APIM-Deployment.html)
-- [04 - Management](APIM-Management.html)
-- [05 - Discovery](APIM-Discovery.html)
-- [06 - Retirement](APIM-Retirement.html)
-
-<table>
-<thead>
-<tr class="header">
-<th>Doc status:</th>
-<th>In progress</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Author:</td>
-<td>Annie Streater</td>
-</tr>
-<tr class="even">
-<td>Reviewers:</td>
-<td><p> Charles Baird<br>
-Arnau Siches<br>
-Steve Evans<br>
-Alicia Matheson</p></td>
-</tr>
-<tr class="odd">
-<td>What user need does this page serve?</td>
-<td><p><strong>Who are the users?</strong></p>
-<ul>
-<li><p>Technologists in government who currently manage a small number of APIs and are considering how to scale</p></li>
-<li><p>Technologists in government who are already using an API Management solution and are looking to review best practice</p></li>
-<li><p>Senior stakeholders in government who review and approve technology spend and strategies</p></li>
-</ul>
-<p><strong>What are they looking for?</strong></p>
-<p>Guidance on:</p>
-<ul>
-<li><p>the benefits of API management tools</p></li>
-<li><p>how API management fits into the API lifecycle</p></li>
-<li>identifying when to use an API Management tool</p></li>
-<li>factors to consider when choosing a solution</p></li>
-<li>how to approach product selection to consider public-facing, open-source solutions and commercial vendors</p></li>
-<li>standards the solution may need to meet, including accessibility</p></li>
-<li>potential customisation needs</p></li>
-<li>how to plan ahead for flexibility and scale</p></li>
-</ul>
-
-<p><strong>How did they find this page?</strong></p>
-<uL>
-<li><p>API design guidance collection</p></li>
-<li>Search results on GOV.UK</p></li>
-</ul>
-
-
-<p><strong>What are the initial problem statements?</strong></p></td>
-</tr>
-<tr class="even">
-<td>Out of scope</td>
-<td>
-<p>This will not include:<br>
-Reference documentation or in-depth technical guidance on how to build</p></td>
-</tr>
-<tr class="odd">
-<td>Page URL/published location:</td>
-<td>On the DSA GitHub Repo, and linked from: <a href="https://www.api.gov.uk/apim/">api.gov.uk/apim/</a></td>
-</tr>
-<tr class="even">
-<td><p>Change note</p></td>
-<td><p>N/A</p></td>
-</tr>
-<tr class="odd">
-<td><p>Annotate the page with these metadata tags:</p></td>
-<td><p>API management, API, API tools, API platform, APIM</p></td>
-</tr>
-</tbody>
-</table>
 
 
 #### Contents:


### PR DESCRIPTION
Adding more "DRAFT" labels to make it clearer.

Removing "user needs" table as this is internal and shouldn't be visible outside the team. 