### PR TITLE
Link to spreadsheet guidance

### DIFF
--- a/content/guidance/spreadsheets/index.html.md
+++ b/content/guidance/spreadsheets/index.html.md
@@ -1,0 +1,14 @@
+---
+title: Spreadsheets guidance
+weight: 860
+keywords: 'spreadsheets'
+identifier: DSA-006
+name: Spreadsheets
+organisation: Data Standards Authority
+status: Active
+startDate: 2021-06-28
+dateAdded: 2021-06-28
+dateUpdated: 2021-06-28
+---
+
+## Read the guidance on [creating and sharing spreadsheets](https://www.gov.uk/guidance/creating-and-sharing-spreadsheets) on GOV.UK.


### PR DESCRIPTION
Added an entry under Guidance for spreadsheet guidance with a link to the live guidance on GOV.UK. This will be a link only as we do not want to duplicate live content. 