### PR TITLE
Added projects folder for service standard work

### DIFF
--- a/projects/data-service-standard/improving-data-guidance-in-service-manual.md
+++ b/projects/data-service-standard/improving-data-guidance-in-service-manual.md
@@ -1,0 +1,27 @@
+# Improving data guidance in the Service Manual
+
+In March and April of 2021, the Data Standards Authority (DSA) undertook five workshops with a total of around 100 data experts from across government, as part of work to improve standards and assurance of government services’ data-related work.
+
+The data experts provided extensive points and ideas on how to improve data in government. Themes included data quality, architecture, interoperability and information sources used amongst many others.
+
+The DSA is now collaborating with the Community-led [Service Standard](https://www.gov.uk/service-manual/service-standard) and [Service Manual](https://www.gov.uk/service-manual) team, with a focus on the Service Manual’s end users, researching the needs of data-related standards and guidance. These users include people with expert data capabilities, but also data newcomers.
+
+We aim to discover what data-related guidance is needed to improve the Service Manual, help service teams meet the requirements of the Service Standard, and support the priorities identified by data experts.
+
+The kinds of things we’re looking to understand about our end users include:
+* who the audience is for data guidance
+* current data practices
+* gaps in existing data guidance
+* barriers to implementing current data guidance
+
+We’ll look at more specific questions, like:
+* What drives users to data-related guidance? What are they trying to find out?
+* What are users’ responsibilities relating to data architecture, life cycle, management and * quality control?
+* What works well and less well about how teams collect, store, process, share, and publish data?
+* Are teams aware of the technical, legal, and ethical standards that they need to meet?
+
+The findings will help us ensure guidance is realistic and reflects the needs of people working with data and makes sense to people with all levels of data capability.
+
+A DSA team member will attend all research sessions as an observer, because user research is a team sport.
+
+We will keep communities and stakeholders up to date by working in the open and sharing developing timelines, information, content and artefacts.  


### PR DESCRIPTION
Created a new 'projects' folder in the repo's root directory where we can publish content/documentation on GitHub to work in the open but not necessarily have it appear on the Standards Catalogue.

Within this, added a document we want to publish as part of the Service Standards project.