### PR TITLE
Use name for the H1 if there is no title

### DIFF
--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -1,7 +1,11 @@
 <% wrap_layout :layout do %>
 
   <div style = "overflow-x:auto;">
-    <h1><%= current_page.data.title %></h1>
+    <% if !current_page.data.title.nil? %>
+      <h1><%= current_page.data.title %></h1>
+    <% else %>
+      <h1><%= current_page.data.name %></h1>
+    <% end %>
     <table style="width:100%">
       <% current_page.data.each do |key, value| %>
         <tr>


### PR DESCRIPTION
If the title isn't provided in the frontmatter on the standards pages, use the name as a fallback option. If neither are provided the H1 won't display.