### PR TITLE
Don't construct `report_issue_url` through string manipulation + improve feedback process for emails

### DIFF
--- a/standards-catalogue/lib/govuk_tech_docs/contribution_banner.rb
+++ b/standards-catalogue/lib/govuk_tech_docs/contribution_banner.rb
@@ -51,9 +51,8 @@ module GovukTechDocs
     def contact_email
       email = current_page.data.author_email || config[:tech_docs][:contact_email]
 
-      subject = current_page.data.title
       params = {
-        subject: "Feedback on #{subject}",
+        subject: "Feedback on '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})",
       }
 
       "mailto:#{email}?#{URI.encode_www_form(params)}"


### PR DESCRIPTION
A few tweaks I spotted we could add:

- Don't construct `report_issue_url` through string manipulation
- Simplify conditional logic in `contact_email`
- Improve `Feedback via email` subject line
