### PR TITLE
Generate links in navbar rather than hard code them

### DIFF
--- a/standards-catalogue/helpers/navigation_helpers.rb
+++ b/standards-catalogue/helpers/navigation_helpers.rb
@@ -1,11 +1,11 @@
 module NavigationHelpers
-  def render_sidebar(resources)
+  def populate_navbar(resources)
     root_page = resources.detect { |r| r.path == "index.html" }
     top_level_pages = navigable_pages(root_page.children).sort_by { |page| page.data.weight || 99_999 }
     navigation = []
 
     navigation << navigation_html(root_page)
-    navigation += top_level_pages.map { |page| navigation_html_with_subpages(page) }
+    navigation += top_level_pages.map { |page| navigation_html(page) }
     navigation.join
   end
 
@@ -18,26 +18,13 @@ private
   end
 
   def navigation_html(page)
-    <<~HTML
-      <ul>
+    unless page.data.title.include? "DSA"
+      <<~HTML
         <li>
           <a href="#{page.url}"><span>#{page.data.title}</span></a>
           #{yield if block_given?}
         </li>
-      </ul>
-    HTML
-  end
-
-  def navigation_html_with_subpages(page)
-    nested_navigation = nil
-    navigable_children = navigable_pages(page.children)
-
-    if navigable_children.any?
-      nested_navigation = navigable_children
-        .map { |child_page| navigation_html(child_page) }
-        .join
+      HTML
     end
-
-    navigation_html(page) { nested_navigation }
   end
 end

--- a/standards-catalogue/source/layouts/core.erb
+++ b/standards-catalogue/source/layouts/core.erb
@@ -45,9 +45,7 @@
           <nav>
             <ul class="contribution-banner navbar">
               <li><%= partial 'layouts/search' %></li>
-              <li><%= link_to "Standards", "/standards/" %></li>
-              <li><%= link_to "Use Cases", "/usecases/" %></li>
-              <li><%= link_to "Guidance", "/guidance/" %></li>
+              <%= populate_navbar(sitemap.resources) %>
             </ul>
           </nav>
           <main id="content" class="technical-documentation" data-module="anchored-headings">


### PR DESCRIPTION
At the moment the links don't work as they are different for local development.
Generate them rather than hard code them to avoid this issue, and so that they
work both locally and on the live site.

We can reuse most of the code that was used to generate the sidebar previously for this.