### PR TITLE
Don't include root page in nav bar

### DIFF
--- a/standards-catalogue/helpers/navigation_helpers.rb
+++ b/standards-catalogue/helpers/navigation_helpers.rb
@@ -3,8 +3,6 @@ module NavigationHelpers
     root_page = resources.detect { |r| r.path == "index.html" }
     top_level_pages = navigable_pages(root_page.children).sort_by { |page| page.data.weight || 99_999 }
     navigation = []
-
-    navigation << navigation_html(root_page)
     navigation += top_level_pages.map { |page| navigation_html(page) }
     navigation.join
   end
@@ -18,13 +16,11 @@ private
   end
 
   def navigation_html(page)
-    unless page.data.title.include? "DSA"
-      <<~HTML
-        <li>
-          <a href="#{page.url}"><span>#{page.data.title}</span></a>
-          #{yield if block_given?}
-        </li>
-      HTML
-    end
+    <<~HTML
+      <li>
+        <a href="#{page.url}"><span>#{page.data.title}</span></a>
+        #{yield if block_given?}
+      </li>
+    HTML
   end
 end


### PR DESCRIPTION
Before we were checking if the page title includes 'DSA', which could have led to returning nil: https://github.com/alphagov/data-standards-authority/pull/79/files#r734620618

We could filter the results instead but actually it's simpler just to not explicitly include it.