### PR TITLE
Improve formatting for search

### DIFF
--- a/standards-catalogue/source/stylesheets/modules/_search.scss
+++ b/standards-catalogue/source/stylesheets/modules/_search.scss
@@ -45,10 +45,8 @@ html.has-search-results-open {
     -ms-overflow-style: none;
     @include govuk-media-query(tablet) {
       padding: govuk-spacing(6);
-      top: 0;
-      // The width of the sidebar
-      left: 230px;
-      left: 14.375rem;
+      top: 100px;
+      top: 6.25rem;
     }
 
     a:link, a:visited {


### PR DESCRIPTION
The search results were [too narrow](https://github.com/alphagov/data-standards-authority/issues/80):

![Screenshot 2021-10-25 at 14 29 42](https://user-images.githubusercontent.com/13121570/138704612-59731b98-931e-4bbd-a254-c604c0279fd7.png)
  

This makes it wider:  


![Screenshot 2021-10-26 at 09 22 13](https://user-images.githubusercontent.com/13121570/138837545-2eac2aa8-7d3d-4476-9934-9a318adec7ac.png)


This doesn't change how it looks on smaller screens, where it still covers the whole width of the screen.

Also fixes an issue where the search bar was covered by the results as soon as you start typing on mobile:

![Screenshot 2021-10-25 at 11 14 37](https://user-images.githubusercontent.com/13121570/138703469-ec5451e9-6512-4842-968d-98d92976575d.png)


Now looks like this on mobile screens (there's no difference to how it looks on larger screens):

![Screenshot 2021-10-25 at 14 24 48](https://user-images.githubusercontent.com/13121570/138703786-6405355f-8830-4375-8c87-9551ab4d4a0b.png)


Closes #80 