### PR TITLE
WIP: Use consistent schema for standards' pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Lint
         run: bundle exec rubocop --parallel
 
+      - name: Validate schemas
+        run: bundle exec rake schema
+
       - name: Build
         run: bundle exec rake build
 

--- a/adr/0001-standards-catalogue-data-structure.md
+++ b/adr/0001-standards-catalogue-data-structure.md
@@ -1,0 +1,85 @@
+---
+creation_date: 2021-11-09
+decision_date: null
+status: proposed
+---
+# Define the schema for the standards catalogue
+
+## Context
+
+The Standards Catalogue, which sits under the Data Standards Authority Workbench (DSA Workbench), is used to capture standards that the DSA are looking at, before they become official guidance on Gov.UK.
+
+As part of plans to enhance the Workbench by producing schema.org metadata, we discovered that the underlying data wasn't quite standardised.
+
+Although this is currently a static website, at some point it may progress into a fully fledged application with a data store, and we want to take this opportunity to invest in a forward-thinking data model, which would work with a backing data store.
+
+## Decision
+
+The Entity Relationship Diagram can be seen below:
+
+![Entity Relationship Diagram for the Standards Catalogue](https://kroki.io/erd/svg/eNqNkrFugzAQhnc_hcUYyJC1WweGqhUgkqqqEIpc-xKdCobaplVV8e41JlEMqUgHS77zd-ff_7nYGiYFU6IkKxQgDR4QFJGsBvpDK_YG1R0NtFEojxFV8NGhAhHQnvBGGsW4wUbeIHUL3LblbGD3_2g9LehU5fE2WoIFM373IZziAjRX2M5k10y9i-ZLDkSoDTOd3qMgoWla5G5XIQfJwe1rhtLYBWoISRF_WuN06SqdmY66tBlF-ZqC3pZtHXBtvK_RYrtBw03qadQ34S53Xrncn0a8AJjv1gNAdnWRZnESZXma5Q_x7j5_jZ6TxyR9SUqLuzF5U3JPTNWRSdRuNn_9sIXr5_0mh-T8belmvV7RczRJh9Q5N8lt6MmnWdbXOTsap0R-AdY7GFM=)
+
+This allows a set of specific information to be available in each Standard, and:
+
+- Gives us the opportunity to track the catalogue status events that an entry goes through, such as _In Review_ to _Endorsed_, without it being tracked as a set of fields in the `Standard` itself
+- We decided that `specification_*` information would sit within the `Standard`, as it was very unlikely that we would produce multiple `Standard`s that had the same `specification`
+- License categorisation was added to make it clearer to the consumers of the site whether the licensing of the standard is Open/Proprietary, with the option to also add Unknown for cases where it is difficult to tell
+
+<details>
+
+<summary>Entity Relationship Diagram (raw)</summary>
+
+```erd
+[Standard]
+*identifier
+name { label: "string, required" }
+contraction { label: "string, required" }
+specification_name { label: "string, required" }
+specification_url { label: "url, required" }
+specification_date { label: "date, required" }
+description { label: "markdown" }
++status_id
++topic_id
++licence_id
++maintainer_id
+
+[Events]
++standard_id
++status_id
+date {label: "date"}
+
+[Status]
+*identifier
+name
+description
+
+[Topic]
+*identifier
+name
+description
+
+[Licence]
+*identifier {label: "string, required"}
+name {label: "string, required"}
+type {label: "enum[OPEN,PROPRIETARY,UNKNOWN]"}
+url {label: "url"}
+
+[Organisation]
+*identifier
+name {label: "string, required"}
+url {label: "url, required"}
+
+Standard 1--* Standard
+Standard 1--+ Topic
+Standard 1--1 Licence
+Standard 1--1 Organisation
+Standard 1--1 Status
+```
+
+</details>
+
+## Consequences
+
+As the site is currently a static website, and is being contributed to by folks with a mix of technical skills, we have opted to prioritise the use of YAML frontmatter in Markdown files, aiming to allow modifying only one file where possible to add a standard.
+
+For instance, this means that the `Events` data will for now be stored in the frontmatter, instead of separately.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,19 @@
+---
+creation_date: 1970-01-01
+decision_date: null
+status: proposed|accepted|rejected|deprecated|superseded
+---
+
+# Title
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/content/guidance/index.html.md.erb
+++ b/content/guidance/index.html.md.erb
@@ -20,7 +20,7 @@ These pieces of guidance are in development by the Data Standards Authority. We 
         <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("guidance/") %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:guidance, f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/guidance/index.html.md.erb
+++ b/content/guidance/index.html.md.erb
@@ -20,7 +20,7 @@ These pieces of guidance are in development by the Data Standards Authority. We 
         <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("guidance/") %> </td>
-              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
+              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -14,6 +14,7 @@ classification: Domain Specific
 
 
 The 360Giving Data Standard is:
+
  - Open data driven - providing a common way to share information on grantmaking.
  - Easy to use - with a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, JSON serialisation and conversion tools.
  - Comprehensive - providing a 360 degree view of grantmaking and supporting in-depth analysis of grants, grantees and beneficiaries.

--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -1,14 +1,19 @@
 ---
-title: 360Giving Schema
-category: Domain Specific
-topic:	5.7 Grants, Loans & Subsidies
-subject: Payments Clearing and Settlement
-organisation: threesixtygiving
 name: 360Giving Schema
-status: review
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
-classification: Domain Specific
+contraction: 360GS
+specification:
+  name: 360Giving
+  url: https://standard.threesixtygiving.org/en/latest/reference/#spreadsheet-format
+  published: "2018-06-01"
+license_id: CC-BY-4.0
+maintainer: threesixtygiving
+catalogue_status_events:
+- status: review
+  date: "2021-02-02"
+topics:
+- Domain Specific
+- 5.7 Grants, Loans & Subsidies
+- Payments Clearing and Settlement
 ---
 
 
@@ -18,7 +23,7 @@ The 360Giving Data Standard is:
  - Open data driven - providing a common way to share information on grantmaking.
  - Easy to use - with a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, JSON serialisation and conversion tools.
  - Comprehensive - providing a 360 degree view of grantmaking and supporting in-depth analysis of grants, grantees and beneficiaries.
- 
+
 
 ## Guidance:
 

--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -1,18 +1,19 @@
 ---
-title: UK Gemini
-keywords: Semantics
-identifier: UK-123
-link: https://www.agi.org.uk/agi-groups/standards-committee/uk-gemini
-isRelatedTo: ISO 19139
 name: UK Gemini
-supersededBy: 2.3
-organisation: Geospatial Commission
-validFrom: Jun-18
-status: active
-startDate: 2020-12-01
-dateAdded: 2020-12-16
-dateUpdated: 2020-12-16
-classification: Metadata
+contraction: GEMINI
+specification:
+  name: 'UK-GEMINI Standard and Inspire Implementing Rules'
+  url: https://www.agi.org.uk/gemini/40-gemini/1037-uk-gemini-standard-and-inspire-implementing-rules/
+  published: '2018-06'
+maintainer: Geospatial Commission
+catalogue_status_events:
+- status: active
+  date: "2020-12-01"
+topics:
+- Metadata
+- Semantics
+identifier: UK-123
+license_id: 'CC-BY-4.0'
 ---
 
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -1,16 +1,20 @@
 ---
-title: UPRN
 name: UPRN
-organisation: Ordnance Survey
+contraction: UPRN
+specification:
+  name: 'Identifying property and street information'
+  url: https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information
+  published: '' # maybe 2020-12-04
+maintainer: Ordnance Survey
+catalogue_status_events:
+- status: active
+  date: "2020-12-02"
+topics:
+- Identification
+- Geospatial
+- Common Reference Data
 identifier: UKABC-123
-link: https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information
-keywords: Identification, geospatial
-isRelatedTo: BS 7666-2:2006
-validFrom: 2020-07-1
-status: active
-dateAdded: 2020-12-16
-dateUpdated: 2020-12-16
-classification: Common Reference Data
+license_id: 'OGL-UK-3.0'
 ---
 
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -1,5 +1,5 @@
 ---
-name: UPRN
+name: Unique Property Reference Number
 contraction: UPRN
 specification:
   name: 'Identifying property and street information'

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -25,7 +25,7 @@ The Data Standards Catalogue currently contains the following Standards:
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:standard, f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -15,7 +15,6 @@ The Data Standards Catalogue currently contains the following Standards:
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Name</th>
-        <th scope="col" class="govuk-table__header">Classification</th>
         <th scope="col" class="govuk-table__header">Status</th>
       </tr>
     </thead>
@@ -24,8 +23,8 @@ The Data Standards Catalogue currently contains the following Standards:
       <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
-              <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><%= display_status(:standard, f.data.status) %></td>
+              <% status = f.data.catalogue_status_events.last.status %>
+              <td class="govuk-table__cell"><%= display_status(:standard, status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -25,7 +25,7 @@ The Data Standards Catalogue currently contains the following Standards:
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
+              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -1,16 +1,20 @@
 ---
-title: Universal financial industry message scheme
-category: Domain Specific
-topic: 5.5 Payment
-subject: Payments Clearing and Settlement
-organisation:	ISO
-reference:	ISO 20022
-identifier:	pacs
 name: Universal financial industry message scheme
-status: review
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
-classification: Domain Specific
+contraction: ISO20022
+specification:
+  name: Universal financial industry message scheme
+  url: https://www.iso20022.org/iso-20022-message-definitions
+  published: "2013-05"
+maintainer: ISO
+license_id: 'Proprietary'
+catalogue_status_events:
+- status: review
+  date: "2012-02-02"
+topics:
+- Domain Specific
+- '5.5 Payment'
+- Payments Clearing and Settlement
+identifier:	pacs
 ---
 
 

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -1,15 +1,20 @@
 ---
-title: ODF 1.2
-category: Data, Information and Records Management Lifecycle
-topic: 4.7 Content Management
-subject: OpenDocuments (ODF)
-reference:	ODF 1.2
 name: ODF 1.2
-keywords: "OpenDocuments"
-status: active
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
-classification: Data, Information and Records Management Lifecycle
+contraction: ODF1.2
+specification:
+  name: Open Document Format for Office Applications (OpenDocument) Version 1.2
+  url: https://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html
+  published: "2011-09-29"
+maintainer: OASIS ODF Technical Committee
+catalogue_status_events:
+- status: active
+  date: "2012-02-02"
+topics:
+- 4.7 Content Management
+- Data, Information and Records Management Lifecycle
+- "OpenDocuments"
+identifier: ODF 1.2
+license_id: '' # TODO: https://en.wikipedia.org/wiki/OpenDocument#Licensing
 ---
 
 

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -1,14 +1,19 @@
 ---
-title: OpenReferralUK
 name: OpenReferralUK
-organisation: Open Referral UK
-keywords: "Service Referrals"
+contraction: ORUK
+specification:
+  name: 'Open Referral UK'
+  url: https://openreferraluk.org/about-standard
+  published: '2020-11-18'
+maintainer: Open Referral UK
+catalogue_status_events:
+- status: review
+  date: "2020-12-01"
+topics:
+- Service, Product, Application, System or Platform Design
+- "Service Referrals"
 identifier: UK123-ZXY
-link: https://openreferraluk.org/
-status: review
-dateAdded: 2020-12-16
-dateUpdated: 2021-07-05
-classification: Service, Product, Application, System or Platform Design
+license_id: 'CC-BY-SA-4.0'
 ---
 
 

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -16,6 +16,7 @@ classification: Data, Information and Records Management Lifecycle
 
 
 You can use this standard for publishing data, where your data has a variety of uses and is for many users. This standard does not cover non-tabular models of data. For example:
+
 - multiple tables with relations, such as SQL
 - hierarchical/flexible records, such as XML or JSON
 - geographic, such as GeoJSON

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -1,16 +1,20 @@
 ---
-title: Common Format and MIME Type for Comma-Separated Values (CSV) Files
-category: Data, Information and Records Management Lifecycle
-topic: 4.7 Content Management
-subject: Tabular Data
-organisation: ietf
-reference:	RFC 4180
-name: RFC 4180 Common Format and MIME Type for Comma-Separated Values (CSV) Files
-keywords: "OpenDocuments"
-status: active
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
-classification: Data, Information and Records Management Lifecycle
+name: Common Format and MIME Type for Comma-Separated Values (CSV) Files
+contraction: RFC4180
+specification:
+  name: Common Format and MIME Type for Comma-Separated Values (CSV) Files
+  url: https://tools.ietf.org/html/rfc4180
+  published: 2005-10
+maintainer: ietf
+catalogue_status_events:
+- status: active
+  date: "2021-02-02"
+topics:
+- 4.7 Content Management
+- Data, Information and Records Management Lifecycle
+- "OpenDocuments"
+- Tabular Data
+license_id: 'BCP-78'
 ---
 
 

--- a/standards-catalogue/.schema/standards.json
+++ b/standards-catalogue/.schema/standards.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://github.com/alphagov/data-standards-authority/blob/main/standards-catalogue/.schema/standards.json",
+  "title": "Data Standards Authority Standards objects",
+  "description": "A JSON Schema to manage the format of Standards objects",
+  "type": "object",
+  "required": [
+    "name",
+    "contraction",
+    "specification",
+    "maintainer",
+    "catalogue_status_events",
+    "topics",
+    "license_id"
+  ],
+  "properties": {
+    "identifier": {
+      "$comment": "The unique identifier assigned to this standard",
+      "type": "string"
+    },
+    "name": {
+      "$comment": "The title or name of the standard",
+      "type": "string",
+      "maxLength": 70
+    },
+    "contraction": {
+      "$comment": "A shorter way of referring to the standard, for instance via an acronym",
+      "type": "string",
+      "maxLength": 10
+    },
+    "specification": {
+      "$ref": "#/definitions/specification"
+    },
+    "maintainer": {
+      "$comment": "The name or identifier of the organisation that maintains the standard",
+      "type": "string"
+    },
+    "catalogue_status_events": {
+      "$comment": "The events that this standard's status has been through",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/catalogue_status_event"
+      }
+    },
+    "topics": {
+      "$comment": "The overarching topics that this fits under",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/topic"
+      }
+    },
+    "description": {
+      "$comment": "The long-form description of the standard, for instance written using Markdown",
+      "type": "string"
+    },
+    "license_id": {
+      "$comment": "A Software Package Data Exchange (SPDX) license identifier, if applicable, or `Proprietary` / `Unknown`",
+      "type": "string",
+      "pattern": "(Proprietary|Unknown|.+)",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "topic": {
+      "$comment": "The human-readable topic descriptions that this standard relates to ",
+      "type": "string"
+    },
+    "specification": {
+      "$comment": "A container object to store information about the specification that this standard relates to",
+      "type": "object",
+      "required": [
+        "name",
+        "url",
+        "published"
+      ],
+      "properties": {
+        "name": {
+          "$comment": "A the name of the specification for the standard",
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "$comment": "A link to a publicly accessible specification for the standard",
+          "type": "string",
+          "pattern": "^https?://.*"
+        },
+        "published": {
+          "$comment": "The date that the specification was published",
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "catalogue_status_event": {
+      "$comment": "A change in status for a standard, for the purpose of the standards catalogue's workflow",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/status"
+        },
+        "date": {
+          "$comment": "Date that the change in status occurred",
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "review"
+      ]
+    }
+  }
+}

--- a/standards-catalogue/Gemfile
+++ b/standards-catalogue/Gemfile
@@ -36,3 +36,6 @@ gem "middleman-sprockets"
 gem "redcarpet"
 gem "sass"
 gem "sprockets"
+
+gem "json-schema"
+gem "spdx"

--- a/standards-catalogue/Gemfile.lock
+++ b/standards-catalogue/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     kramdown (2.3.1)
       rexml
     listen (3.0.8)
@@ -127,6 +129,7 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
+    polyglot (0.3.5)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -187,6 +190,8 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     servolux (0.13.0)
+    spdx (4.1.1)
+      treetop (~> 1.6)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -196,6 +201,8 @@ GEM
     tilt (2.0.10)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
+    treetop (1.6.11)
+      polyglot (~> 0.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
@@ -210,6 +217,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   factory_bot
+  json-schema
   middleman (>= 4.4.0, < 5.0)
   middleman-autoprefixer
   middleman-compass
@@ -222,10 +230,11 @@ DEPENDENCIES
   rspec
   rubocop-govuk
   sass
+  spdx
   sprockets
   sqlite3
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.26

--- a/standards-catalogue/Rakefile
+++ b/standards-catalogue/Rakefile
@@ -31,9 +31,21 @@ task :build do
   sh "bundle exec middleman build --clean --bail"
 end
 
-task schema: ["schema:standards"]
+task schema: ["schema:standards", "schema:data_files"]
 
 namespace :schema do
+  namespace :data_files do
+    desc "Validate that the Status data file matches standards"
+    task :status do
+      schema = schema("standards")
+      schema_options = schema["definitions"]["status"]["enum"]
+      data_options = YAML.load_file("data/statuses.yml")
+      raise "Statuses are mismatched between schema and data file" unless schema_options == data_options.keys
+    end
+  end
+
+  task data_files: ["data_files:status"]
+
   desc "Validate Standards are schema compliant"
   task :standards do
     schema = schema("standards")

--- a/standards-catalogue/Rakefile
+++ b/standards-catalogue/Rakefile
@@ -1,15 +1,47 @@
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
+require "json-schema"
+
+def schema(schema_name)
+  JSON.parse(File.read(".schema/#{schema_name}.json"))
+end
+
+def validate_schema!(schema, file_to_validate)
+  to_validate = YAML.load_file(file_to_validate)
+
+  options = {
+  }
+
+  errors = JSON::Validator.fully_validate(schema, to_validate, options).to_a
+  return true if errors.empty?
+
+  puts "Validation failed while trying to validate `#{file_to_validate}`: "
+  jj errors
+  false
+end
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: ["spec", "rubocop:auto_correct"]
+task default: ["spec", "rubocop:auto_correct", "schema"]
 
 desc "Build site"
 task :build do
   sh("rsync -a ../content/ source")
   sh "bundle exec middleman build --clean --bail"
+end
+
+task schema: ["schema:standards"]
+
+namespace :schema do
+  desc "Validate Standards are schema compliant"
+  task :standards do
+    schema = schema("standards")
+    errors = Dir.glob("../content/standards/*/*.md").map do |f|
+      validate_schema!(schema, f)
+    end
+    raise unless errors.all?
+  end
 end
 
 desc "Publish build to Github pages"

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -81,9 +81,9 @@ helpers do
     end
   end
 
-  def display_status(id)
-    if data.statuses[id]
-      status = data.statuses[id]
+  def display_status(type, id)
+    if data.statuses[type] && data.statuses[type][id]
+      status = data.statuses[type][id]
       "<span class='#{status.styling}'>#{status.name}</span>"
     else
       id

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -83,7 +83,8 @@ helpers do
 
   def display_status(id)
     if data.statuses[id]
-      data.statuses[id].name
+      status = data.statuses[id]
+      "<span class='#{status.styling}'>#{status.name}</span>"
     else
       id
     end

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -99,6 +99,31 @@ helpers do
       page.path.delete_prefix("standards/").chomp("/index.html")
     end
   end
+
+  def license_information(license_id)
+    if license_id == "Proprietary"
+      {
+        type: "Proprietary",
+        description: "License is not based on an Open Standard, and may require payment or contract to use",
+      }
+    elsif license_id == "Unknown"
+      {
+        type: "Unknown",
+        description: "The license could not be determined - it may be an Open Standard that is unclear, or it may be Proprietary",
+      }
+    elsif Spdx.license_exists?(license_id)
+      license = Spdx.licenses[license_id]
+      {
+        type: "Open Standard",
+        description: "<a href='#{license['seeAlso'][0]}'>#{license['name']}</a>",
+      }
+    else
+      {
+        type: "Unknown",
+        description: "The license, <code>#{license_id}</code>, is not a known license",
+      }
+    end
+  end
 end
 
 page "/*.xml", layout: false

--- a/standards-catalogue/data/statuses.yml
+++ b/standards-catalogue/data/statuses.yml
@@ -1,12 +1,14 @@
-active:
-  name: Endorsed
-  styling: status-active
-draft:
-  name: Draft
-  styling: status-draft
-review:
-  name: In review
-  styling: status-draft
-published:
-  name: Published
-  styling: status-active
+standard:
+  active:
+    name: Endorsed
+    styling: status-active
+  review:
+    name: In review
+    styling: status-draft
+guidance:
+  draft:
+    name: Draft
+    styling: status-draft
+  published:
+    name: Published
+    styling: status-active

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -15,7 +15,7 @@
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
           <% elsif key == 'status' %>
-            <td nowrap><strong><%= display_status(value) %></strong> </td>
+            <td nowrap><strong><%= display_status(:standard, value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -15,7 +15,7 @@
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
           <% elsif key == 'status' %>
-            <td nowrap><strong class=<%= data.statuses[value].styling %>><%= display_status(value) %></strong> </td>
+            <td nowrap><strong><%= display_status(value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -1,26 +1,60 @@
 <% wrap_layout :layout do %>
 
   <div style = "overflow-x:auto;">
-    <% if !current_page.data.title.nil? %>
-      <h1><%= current_page.data.title %></h1>
-    <% else %>
-      <h1><%= current_page.data.name %></h1>
-    <% end %>
+    <h1><%= current_page.data.name %></h1>
     <table style="width:100%">
-      <% current_page.data.each do |key, value| %>
-        <tr>
-          <td nowrap><%= key.titleize.capitalize %>: </td>
-          <% if key == 'link' %>
-            <td nowrap><strong><a href='<%= value %>'><%= value %></a></strong> </td>
-          <% elsif key == 'organisation' %>
-            <td nowrap><strong><%= display_organisation(value) %></strong> </td>
-          <% elsif key == 'status' %>
-            <td nowrap><strong><%= display_status(:standard, value) %></strong> </td>
-          <% else %>
-            <td nowrap><strong><%= value %></strong> </td>
-          <% end %>
-        </tr>
-      <% end %>
+      <tr>
+        <td>Name</td>
+        <td>
+          <strong><%= current_page.data.name %></strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Also Known As</td>
+        <td>
+          <strong><%= current_page.data.contraction %></strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Status</td>
+        <td>
+          <% status = current_page.data.catalogue_status_events.last.status %>
+          <strong><%= display_status(:standard, status) %></strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Specification</td>
+        <td>
+          <strong><a href="<%= current_page.data.specification.url %>"><%= current_page.data.specification.name %></a></strong> (published <%= current_page.data.specification.published %>)
+        </td>
+      </tr>
+
+      <tr>
+        <td>License</td>
+        <td>
+          <% license_info = license_information(current_page.data.license_id) %>
+          <strong> <%= license_info[:type] %></strong> - <%= license_info[:description] %>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Maintained By</td>
+        <td><strong><%= display_organisation(current_page.data.maintainer) %></strong> </td>
+      </tr>
+
+      <tr>
+        <td>Topics</td>
+        <td>
+          <ul>
+            <% current_page.data.topics.each do |topic| %>
+              <li><strong><%= topic %></strong></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
     </table>
   </div>
 


### PR DESCRIPTION
As a step towards being able to produce metadata for the standards
pages, we should use a consistent model across our standards.

To do this, we add a JSON schema for the standards, which attempts to
make as much required and formatted appropriately.

This requires we:

- wrap string fields, where appropriate, in string quotes
- remove the redundant `name` field, as it duplicates `title`
- remove the redundant `category` field, as it duplicates
  `classification`
- where fields are likely to be not free-form, we can mark them as
  `enum`s

This uses the `json-schema` library, as it's got nice error reporting,
but unfortunately is stuck on `draft-04` of JSON Schema.

TODO:

- [ ] what is the data model we actually want?
- [ ] ADR for what we're deciding