### PR TITLE
Centre header and footer

### DIFF
--- a/standards-catalogue/source/layouts/_header.erb
+++ b/standards-catalogue/source/layouts/_header.erb
@@ -2,11 +2,11 @@
   <div class="govuk-header__container govuk-header__container--full-width">
     <div class="govuk-header__logo">
       <% if config[:tech_docs][:service_link] %>
-      <a href="<%= url_for config[:tech_docs][:service_link] %>" class="govuk-header__link govuk-header__link--homepage">
+        <a href="<%= url_for config[:tech_docs][:service_link] %>" class="govuk-header__link govuk-header__link--homepage">
       <% else %>
       <span class="govuk-header__link govuk-header__link--homepage">
       <% end %>
-        <% if config[:tech_docs][:show_govuk_logo] %>
+      <% if config[:tech_docs][:show_govuk_logo] %>
         <span class="govuk-header__logotype">
           <svg
             aria-hidden="true"
@@ -27,32 +27,34 @@
             GOV.UK
           </span>
         </span>
-        <% end %>
-        <span class="govuk-header__product-name">
+      <% end %>
+      <span class="govuk-header__product-name">
           <%= config[:tech_docs][:service_name] %>
         </span>
       <% if config[:tech_docs][:service_link] %>
-      </a>
+        </a>
       <% else %>
-      </span>
+        </span>
       <% end %>
       <% if config[:tech_docs][:phase] %>
         <strong class="govuk-tag"><%= config[:tech_docs][:phase] %></strong>
       <% end %>
     </div>
     <% if config[:tech_docs][:header_links] %>
-    <div class="govuk-header__content">
-      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-      <nav>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-          <% config[:tech_docs][:header_links].each do |title, path| %>
-            <li class="govuk-header__navigation-item<% if active_page(path) %> govuk-header__navigation-item--active<% end %>">
-              <a class="govuk-header__link" href="<%= url_for path %>"><%= title %></a>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
-    </div>
+      <div class="govuk-header__content">
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <nav>
+          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+            <% config[:tech_docs][:header_links].each do |title, path| %>
+              <li class="govuk-header__navigation-item
+                <% if active_page(path) %> govuk-header__navigation-item--active
+                <% end %>">
+                <a class="govuk-header__link" href="<%= url_for path %>"><%= title %></a>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
+      </div>
     <% end %>
   </div>
 </header>

--- a/standards-catalogue/source/layouts/_header.erb
+++ b/standards-catalogue/source/layouts/_header.erb
@@ -1,12 +1,13 @@
 <header class="govuk-header app-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-header__container--full-width">
-    <div class="govuk-header__logo">
-      <% if config[:tech_docs][:service_link] %>
-        <a href="<%= url_for config[:tech_docs][:service_link] %>" class="govuk-header__link govuk-header__link--homepage">
-      <% else %>
+    <div class="header-content">
+      <div class="govuk-header__logo">
+        <% if config[:tech_docs][:service_link] %>
+          <a href="<%= url_for config[:tech_docs][:service_link] %>" class="govuk-header__link govuk-header__link--homepage">
+        <% else %>
       <span class="govuk-header__link govuk-header__link--homepage">
-      <% end %>
-      <% if config[:tech_docs][:show_govuk_logo] %>
+        <% end %>
+        <% if config[:tech_docs][:show_govuk_logo] %>
         <span class="govuk-header__logotype">
           <svg
             aria-hidden="true"
@@ -27,34 +28,35 @@
             GOV.UK
           </span>
         </span>
-      <% end %>
-      <span class="govuk-header__product-name">
+        <% end %>
+        <span class="govuk-header__product-name">
           <%= config[:tech_docs][:service_name] %>
         </span>
-      <% if config[:tech_docs][:service_link] %>
-        </a>
-      <% else %>
-        </span>
-      <% end %>
-      <% if config[:tech_docs][:phase] %>
-        <strong class="govuk-tag"><%= config[:tech_docs][:phase] %></strong>
-      <% end %>
-    </div>
-    <% if config[:tech_docs][:header_links] %>
-      <div class="govuk-header__content">
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <nav>
-          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-            <% config[:tech_docs][:header_links].each do |title, path| %>
-              <li class="govuk-header__navigation-item
+        <% if config[:tech_docs][:service_link] %>
+          </a>
+        <% else %>
+          </span>
+        <% end %>
+        <% if config[:tech_docs][:phase] %>
+          <strong class="govuk-tag"><%= config[:tech_docs][:phase] %></strong>
+        <% end %>
+      </div>
+      <% if config[:tech_docs][:header_links] %>
+        <div class="govuk-header__content">
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <nav>
+            <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+              <% config[:tech_docs][:header_links].each do |title, path| %>
+                <li class="govuk-header__navigation-item
                 <% if active_page(path) %> govuk-header__navigation-item--active
                 <% end %>">
-                <a class="govuk-header__link" href="<%= url_for path %>"><%= title %></a>
-              </li>
-            <% end %>
-          </ul>
-        </nav>
-      </div>
-    <% end %>
+                  <a class="govuk-header__link" href="<%= url_for path %>"><%= title %></a>
+                </li>
+              <% end %>
+            </ul>
+          </nav>
+        </div>
+      <% end %>
+    </div>
   </div>
 </header>

--- a/standards-catalogue/source/stylesheets/modules/_footer.scss
+++ b/standards-catalogue/source/stylesheets/modules/_footer.scss
@@ -6,4 +6,11 @@
     padding-left: govuk-spacing(6);
     padding-right: govuk-spacing(6);
   }
+  @include govuk-media-query($from: desktop) {
+    .govuk-footer__meta-item {
+      max-width: 790px;
+      max-width: 49.375rem;
+      margin: auto;
+    }
+  }
 }

--- a/standards-catalogue/source/stylesheets/modules/_header.scss
+++ b/standards-catalogue/source/stylesheets/modules/_header.scss
@@ -7,10 +7,15 @@
   // Give the product name in the header more space so it does not wrap early on smaller screens.
   @include govuk-media-query($from: desktop) {
     .govuk-header__logo {
-      width: 45%;
+      width: 55%;
     }
     .govuk-header__content {
       width: 55%;
     }
+  }
+  .header-content {
+    max-width: 750px;
+    max-width: 46.875rem;
+    margin: auto;
   }
 }


### PR DESCRIPTION
Centre the header and footer content so that it aligns with the rest of the content on the page and isn't
off to one side.

The change to _header.erb is to add a div, it's a bit difficult to see the actual change in the code because of the formatting changes. Also open to suggestions of better ways to do this.

Before:

<img width="1423" alt="Screenshot 2021-10-27 at 10 08 02" src="https://user-images.githubusercontent.com/13121570/139035740-bca45a56-ea5d-4f4b-831d-8a292c1faf30.png">


<img width="1412" alt="Screenshot 2021-10-27 at 10 14 32" src="https://user-images.githubusercontent.com/13121570/139036793-c65e147d-f9a2-4b26-b401-9bcb9be2c47a.png">

After:  

<img width="1411" alt="Screenshot 2021-10-27 at 11 14 56" src="https://user-images.githubusercontent.com/13121570/139046824-e2662a66-3994-4d8a-ad27-26f5576f7049.png">


<img width="1411" alt="Screenshot 2021-10-27 at 11 17 17" src="https://user-images.githubusercontent.com/13121570/139047172-e0dc13a3-4d9e-4047-80e3-e4051267fc09.png">


