### PR TITLE
Remove /standards-catalogue/ prefix to site

### DIFF
--- a/standards-catalogue/Rakefile
+++ b/standards-catalogue/Rakefile
@@ -27,8 +27,6 @@ task :publish do
   end
 
   sh("rsync -a --delete --exclude .git --exclude CNAME build/data-standards-authority/ #{publish_dir}")
-  # Copy a redirect file from helpers folder to deal with the gh-p push
-  sh("cp helpers/index.html #{publish_dir}")
   sh("git -C #{publish_dir} add --all")
   sh("git -C #{publish_dir} commit -m 'Publish #{rev}'") do |ok, _|
     if ok

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -16,7 +16,6 @@ require "lib/govuk_tech_docs/unique_identifier_extension"
 require "lib/govuk_tech_docs/unique_identifier_generator"
 
 # Project setup
-project_name = "standards-catalogue"
 repo_name = "data-standards-authority"
 
 activate :sprockets
@@ -43,9 +42,9 @@ end
 set(:govuk_assets_path, "/assets/govuk/assets/")
 
 configure :build do
-  set(:build_dir, "build/#{repo_name}/#{project_name}")
-  set(:http_prefix, "/#{repo_name}/#{project_name}/")
-  set(:govuk_assets_path, "/#{repo_name}/#{project_name}/assets/govuk/assets/")
+  set(:build_dir, "build/#{repo_name}")
+  set(:http_prefix, "/#{repo_name}/")
+  set(:govuk_assets_path, "/#{repo_name}/assets/govuk/assets/")
 end
 
 configure :build do

--- a/standards-catalogue/config/tech-docs.yml
+++ b/standards-catalogue/config/tech-docs.yml
@@ -20,9 +20,6 @@ prevent_indexing: false
 show_contribution_banner: true
 github_repo: alphagov/data-standards-authority/
 
-#for gh-pages or other directory views, build the view source link
-project_name: standards-catalogue
-
 #to add feedback email address on pages:
 contact_email: standards-catalogue@digital.cabinet-office.gov.uk
 

--- a/standards-catalogue/helpers/index.html
+++ b/standards-catalogue/helpers/index.html
@@ -1,5 +1,0 @@
-<html>
-<head>
-<meta http-equiv="refresh" content="0; URL='standards-catalogue/'" />
-</head>
-</html>


### PR DESCRIPTION
As noted in #90, the additional /standards-catalogue/ hierarchy,
especially if going to /standards/, can be quite awkward to use.

We can remove this by amending our Tech Docs + Middleman configuration
to no longer use a sub-project from the top-level repo, so this site is
for the DSA project.

Now we're no longer needing the subdirectory, we can remove the
HTML-only redirect.

Closes #90.

---

See https://jamietanna.github.io/data-standards-authority/