### PR TITLE
Update guidance status and minor typos

### DIFF
--- a/content/guidance/index.html.md
+++ b/content/guidance/index.html.md
@@ -2,7 +2,7 @@
 title: Guidance
 weight: 800
 dateAdded: 2021-01-22
-dateUpdated: 2021-02-01
+dateUpdated: 2021-11-03
 ---
 
 # DSA Guidance
@@ -12,8 +12,8 @@ These pieces of guidance are in development by the Data Standards Authority. We 
 
 | Name | Status |
 | --- | --- |
-| **[UK Government Reference Architecture for Data and APIs](referencearchitecture/)** | Draft |
-| **[Publish reference data for use across government](referencedata/)** | Draft |
 | **[API Management Guidance](apimanagement/)** | Draft |
-| **[api.gov.uk Domain Guidance](apidomain/)** | Draft |
-| **[GraphQL Guidance](graphql/)** | Draft |
+| **[UK Government Reference Architecture for Data and APIs](referencearchitecture/)** | Live |
+| **[Publish reference data for use across government](referencedata/)** | Live |
+| **[api.gov.uk Domain Guidance](apidomain/)** | Live |
+| **[GraphQL Guidance](graphql/)** | Live |

--- a/content/guidance/tcop10/index.html.md
+++ b/content/guidance/tcop10/index.html.md
@@ -99,11 +99,11 @@ If you are agreeing a contract of over £20 million, the supplier must provide t
 
 ### Storing and standardising your data
 
-The gGovernment’s [Data Standards Authority](https://www.gov.uk/government/groups/data-standards-authority) and the [Open Standards Board](https://www.gov.uk/government/groups/open-standards-board) have approved a number of [open standards for data](https://www.gov.uk/government/collections/open-standards-for-government-data-and-technology) for use by the government. Where possible and appropriate, you should use these standards to make it easier to analyse data and share it with other departments.
+The government’s [Data Standards Authority](https://www.gov.uk/government/groups/data-standards-authority) and the [Open Standards Board](https://www.gov.uk/government/groups/open-standards-board) have approved a number of [open standards for data](https://www.gov.uk/government/collections/open-standards-for-government-data-and-technology) for use by the government. Where possible and appropriate, you should use these standards to make it easier to analyse data and share it with other departments.
 
-Make data available in a suitable format, for example as a CSV file or through an API. Read the [guidance on using CSV file format](https://www.gov.uk/guidance/using-csv-file-format) and refer toYou should use the [API technical and data standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards).
+Make data available in a suitable format, for example as a CSV file or through an API. Read the [guidance on using CSV file format](https://www.gov.uk/guidance/using-csv-file-format) and refer to the [API technical and data standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards).
 
-You should alsoand consider:
+You should also consider:
 
 -   where you will store your data and whether the location meets your organisation’s security requirements    
 -   having a [cloud hosting strategy](https://www.gov.uk/guidance/creating-and-implementing-a-cloud-hosting-strategy)


### PR DESCRIPTION
Updated guidance index page to mark guidance that is live on GOV.UK as Live. 

Also corrected a few typos in the TCOP draft (deleted text from Google Doc 'suggestions' that got carried over)