### PR TITLE
Prevent header text going onto 2 lines

### DIFF
--- a/standards-catalogue/source/stylesheets/modules/_header.scss
+++ b/standards-catalogue/source/stylesheets/modules/_header.scss
@@ -7,7 +7,7 @@
   // Give the product name in the header more space so it does not wrap early on smaller screens.
   @include govuk-media-query($from: desktop) {
     .govuk-header__logo {
-      width: 55%;
+      width: 65%;
     }
     .govuk-header__content {
       width: 55%;


### PR DESCRIPTION
After centring the header content, the word 'Discovery' in the header is being pushed under the rest of
the text which makes it look squashed and makes the header bigger. Previously it was on one line so this puts it back to that.

Before:

![Screenshot 2021-11-04 at 13 30 45](https://user-images.githubusercontent.com/13121570/140322041-05d48f26-f23e-4851-b949-dfaedadbafb7.png)

After:

![Screenshot 2021-11-04 at 13 31 43](https://user-images.githubusercontent.com/13121570/140322198-dbb152bd-7011-4e6b-b435-ec0195ce8f43.png)


