### PR TITLE
Add a page for external standards catalogues

### DIFF
--- a/content/standards/external-standards.html.md
+++ b/content/standards/external-standards.html.md
@@ -2,7 +2,6 @@
 title: External Standards Catalogues
 exclude_from_list: true
 ---
-
 # External Standards Catalogues
 
 - [Criminal Justice System Exchange Data Standards Catalogue](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/360582/cjs-data-standards-catalogue-5.0.pdf)

--- a/content/standards/external-standards.html.md
+++ b/content/standards/external-standards.html.md
@@ -7,3 +7,4 @@ exclude_from_list: true
 - [Criminal Justice System Exchange Data Standards Catalogue](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/360582/cjs-data-standards-catalogue-5.0.pdf)
 - [NHS information standards](https://digital.nhs.uk/data-and-information/information-standards)
 - [ONS data standards](https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy/datastandards)
+- [LGA data standards](https://standards.esd.org.uk/)

--- a/content/standards/external-standards.html.md
+++ b/content/standards/external-standards.html.md
@@ -1,6 +1,6 @@
 ---
 title: External Standards Catalogues
-
+exclude_from_list: true
 ---
 
 # External Standards Catalogues

--- a/content/standards/external-standards.html.md
+++ b/content/standards/external-standards.html.md
@@ -1,0 +1,10 @@
+---
+title: External Standards Catalogues
+
+---
+
+# External Standards Catalogues
+
+- [Criminal Justice System Exchange Data Standards Catalogue](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/360582/cjs-data-standards-catalogue-5.0.pdf)
+- [NHS information standards](https://digital.nhs.uk/data-and-information/information-standards)
+- [ONS data standards](https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy/datastandards)

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -34,7 +34,8 @@ The Data Standards Catalogue currently contains the following Standards:
 </div>
 
 ## External Standards Catalogues
-You can find a list of external standards catalogues [here](/standards/external-standards.html).
+
+We also have a list of [external standards catalogues](/standards/external-standards.html).
 
 
 

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -36,6 +36,3 @@ The Data Standards Catalogue currently contains the following Standards:
 ## External Standards Catalogues
 
 We also have a list of [external standards catalogues](/standards/external-standards.html).
-
-
-

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -20,8 +20,8 @@ The Data Standards Catalogue currently contains the following Standards:
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% current_resource.children.sort_by{ |page| get_link_text(page).downcase }.each do |f| %>
-        <% if f.content_type.include? "html" %>
+      <% current_resource.children.reject{|page| page.data.exclude_from_list}.sort_by{ |page| get_link_text(page).downcase }.each do |f| %>
+      <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -33,5 +33,8 @@ The Data Standards Catalogue currently contains the following Standards:
   </table>
 </div>
 
+## External Standards Catalogues
+You can find a list of external standards catalogues [here](/standards/external-standards.html).
+
 
 


### PR DESCRIPTION
New page for external catalogues:  

![Screenshot 2021-11-04 at 14 00 19](https://user-images.githubusercontent.com/13121570/140327390-a3675208-5afb-41cd-9e7c-d4f5fc36ddd8.png)  


Link from the standards page:    

![Screenshot 2021-11-04 at 14 00 33](https://user-images.githubusercontent.com/13121570/140327409-37862590-9597-4dd8-a4c8-56714e8ecdda.png) 





