### PR TITLE
Fix: Remove erroneous URL portions in feedback links

### DIFF
--- a/standards-catalogue/lib/govuk_tech_docs/contribution_banner.rb
+++ b/standards-catalogue/lib/govuk_tech_docs/contribution_banner.rb
@@ -20,8 +20,9 @@ module GovukTechDocs
 
     def report_issue_url
       url = config[:source_urls]&.[](:report_issue_url)
+
       params = {
-        body: "Feedback on '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})",
+        body: "Feedback on '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page_url})",
       }
 
       if url.nil?
@@ -52,7 +53,7 @@ module GovukTechDocs
       email = current_page.data.author_email || config[:tech_docs][:contact_email]
 
       params = {
-        subject: "Feedback on '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page.url})",
+        subject: "Feedback on '#{current_page.data.title}' (#{config[:tech_docs][:host]}#{current_page_url})",
       }
 
       "mailto:#{email}?#{URI.encode_www_form(params)}"
@@ -79,6 +80,12 @@ module GovukTechDocs
 
     def locals
       current_page.metadata[:locals]
+    end
+
+    def current_page_url
+      # remove the prefix that appears on the published site, breaking contribution links
+      current_page.url
+        .sub(/\/data-standards-authority/, "")
     end
   end
 end


### PR DESCRIPTION

As spotted in #102, the URLs that are being referenced from the
"Feedback" links are not correct, as they've got an additional
`/data-standards-authority` in them.

A short-term fix is to trim the first instance of the prefix.

It appears that this is an artefact of something we've done on our
mix of Tech Docs template and custom code, as other Tech Docs
projects[0] running on GitHub pages seem to work OK.

Closes #102.

[0]: https://alphagov.github.io/accessibility-personas/ashleigh/

