### PR TITLE
Get status from data file on standards pages

### DIFF
--- a/content/guidance/index.html.md.erb
+++ b/content/guidance/index.html.md.erb
@@ -20,7 +20,7 @@ These pieces of guidance are in development by the Data Standards Authority. We 
         <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("guidance/") %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -5,7 +5,7 @@ topic:	5.7 Grants, Loans & Subsidies
 subject: Payments Clearing and Settlement
 organisation: threesixtygiving
 name: 360Giving Schema
-status: draft
+status: review
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
 classification: Domain Specific

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -25,7 +25,7 @@ The Data Standards Catalogue currently contains the following Standards:
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -7,7 +7,7 @@ organisation:	ISO
 reference:	ISO 20022
 identifier:	pacs
 name: Universal financial industry message scheme
-status: draft
+status: review
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
 classification: Domain Specific

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -5,7 +5,7 @@ organisation: Open Referral UK
 keywords: "Service Referrals"
 identifier: UK123-ZXY
 link: https://openreferraluk.org/
-status: draft
+status: review
 dateAdded: 2020-12-16
 dateUpdated: 2021-07-05
 classification: Service, Product, Application, System or Platform Design

--- a/standards-catalogue/data/statuses.yml
+++ b/standards-catalogue/data/statuses.yml
@@ -5,8 +5,8 @@ draft:
   name: Draft
   styling: status-draft
 review:
-  name: Review
-  styling: status-review
+  name: In review
+  styling: status-draft
 published:
   name: Published
   styling: status-active

--- a/standards-catalogue/data/statuses.yml
+++ b/standards-catalogue/data/statuses.yml
@@ -1,8 +1,12 @@
 active:
   name: Endorsed
+  styling: status-active
 draft:
   name: Draft
+  styling: status-draft
 review:
   name: Review
+  styling: status-review
 published:
   name: Published
+  styling: status-active

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -15,7 +15,7 @@
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
           <% elsif key == 'status' %>
-            <td nowrap><strong><%= display_status(value) %></strong> </td>
+            <td nowrap><strong class=<%= data.statuses[value].styling %>><%= display_status(value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -14,6 +14,8 @@
             <td nowrap><strong><a href='<%= value %>'><%= value %></a></strong> </td>
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
+          <% elsif key == 'status' %>
+            <td nowrap><strong><%= display_status(value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>

--- a/standards-catalogue/source/stylesheets/modules/_app-pane.scss
+++ b/standards-catalogue/source/stylesheets/modules/_app-pane.scss
@@ -61,5 +61,17 @@
       margin-left: $toc-width;
     }
   }
+
+  .status-active {
+    background-color: #8D5;
+  }
+
+  .status-draft {
+    background-color: #ffdd00;
+  }
+
+  .status-review {
+    background-color: #ffac1c;
+  }
 }
 

--- a/standards-catalogue/source/stylesheets/modules/_app-pane.scss
+++ b/standards-catalogue/source/stylesheets/modules/_app-pane.scss
@@ -69,9 +69,5 @@
   .status-draft {
     background-color: #ffdd00;
   }
-
-  .status-review {
-    background-color: #ffac1c;
-  }
 }
 


### PR DESCRIPTION
- Get the status from the status file instead of just the text from the frontmatter. We have a data file with the status in which we use in the contents file. We can also use it in the actual standards files themselves
- Colour code the different statuses to make it visually easier to see the status
- Use 'in review' for standards rather than draft, but still use draft for guidance

<img width="920" alt="Screenshot 2021-11-08 at 15 29 46" src="https://user-images.githubusercontent.com/13121570/140770246-fa642635-aa93-4fa2-a110-1b7707c3e98c.png">
   
<img width="816" alt="Screenshot 2021-11-08 at 15 30 29" src="https://user-images.githubusercontent.com/13121570/140770392-b26ae2ea-af6c-4389-badc-7d44d3d8d3be.png">


<img width="878" alt="Screenshot 2021-11-08 at 15 31 16" src="https://user-images.githubusercontent.com/13121570/140770588-d62c5401-5ece-4881-9743-b3a74890afeb.png">


