### PR TITLE
Move status styling to own file

### DIFF
--- a/standards-catalogue/source/stylesheets/_core.scss
+++ b/standards-catalogue/source/stylesheets/_core.scss
@@ -9,3 +9,4 @@
 @import "modules/technical-documentation";
 @import "modules/collapsible";
 @import "modules/navbar";
+@import "modules/status";

--- a/standards-catalogue/source/stylesheets/modules/_app-pane.scss
+++ b/standards-catalogue/source/stylesheets/modules/_app-pane.scss
@@ -61,13 +61,5 @@
       margin-left: $toc-width;
     }
   }
-
-  .status-active {
-    background-color: #8D5;
-  }
-
-  .status-draft {
-    background-color: #ffdd00;
-  }
 }
 

--- a/standards-catalogue/source/stylesheets/modules/_status.scss
+++ b/standards-catalogue/source/stylesheets/modules/_status.scss
@@ -1,0 +1,7 @@
+.status-active {
+  background-color: #8D5;
+}
+
+.status-draft {
+  background-color: #ffdd00;
+}


### PR DESCRIPTION
Before it was in _app-pane which only contains a block that's applied to tablets and above, so the colours weren't showing on mobile.

Having these styles in a separate file should make them easier to find and use (and won't impact performance of the site as they're combined into a single file when it's built).