### PR TITLE
Fix markdown formatting for lists

### DIFF
--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -14,6 +14,7 @@ classification: Domain Specific
 
 
 The 360Giving Data Standard is:
+
  - Open data driven - providing a common way to share information on grantmaking.
  - Easy to use - with a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, JSON serialisation and conversion tools.
  - Comprehensive - providing a 360 degree view of grantmaking and supporting in-depth analysis of grants, grantees and beneficiaries.

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -16,6 +16,7 @@ classification: Data, Information and Records Management Lifecycle
 
 
 You can use this standard for publishing data, where your data has a variety of uses and is for many users. This standard does not cover non-tabular models of data. For example:
+
 - multiple tables with relations, such as SQL
 - hierarchical/flexible records, such as XML or JSON
 - geographic, such as GeoJSON


### PR DESCRIPTION
In a number of Markdown implementations - including the one we're using
- a list needs a newline before it starts, otherwise it doesn't render
correctly.
