### PR TITLE
Add ADR for Standards

### DIFF
--- a/adr/0001-standards-catalogue-data-structure.md
+++ b/adr/0001-standards-catalogue-data-structure.md
@@ -1,0 +1,81 @@
+---
+creation_date: 2021-11-11
+decision_date: 2021-11-11
+status: accepted
+---
+# Define the schema for the standards portion of the Data Standards Authority Workbench
+
+## Context
+
+The standards section of the Data Standards Authority Workbench (DSA Workbench), is used to capture standards that the DSA are reviewing, before they become official guidance on Gov.UK. It is also an attempt to map other standards in use across government, both for the DSA's internal prioritisation activities and to enable external users to find relevant data standards. To begin with, this second focus is served by curating a list of standards catalogues.
+
+As part of plans to enhance the Workbench by introducing schema.org metadata, we discovered that the underlying data wasn't quite standardised.
+
+Although this is currently a static website, at some point it may progress into a fully fledged application with a data store, and we want to take this opportunity to invest in a forward-thinking data model, which would work with a backing data store.
+
+## Decision
+
+The Entity Relationship Diagram can be seen below:
+
+![Entity Relationship Diagram for Standards](https://kroki.io/erd/svg/eNqlkk1PhDAQhu_9FQ3HhT3s1ZsHDkYDhN2NMYRsxnaWNEJh26Ixhv9uKRABzRrjoU1n-vSdr2Z7A5KD4jnZCI7SiLNARSRUSD9oCc9Y3lBPGyVkEVCFl1Yo5B7tCKulUcCMqOUvpG6QWVkGPXtqVTnjrbWEOWqmRLOSrUC98PpN9oRvoDgJTvxSMJQM3bkCIY1dqHqTZOGrrSUnvh7Lc5A1TKv7Iwdj65vUp_gB7f1eZ9_vHfrnpsyytyIHKP6p8DCUuFD5yvvb-26McAUw780MQNlWWZyEUZCkcZLehYfb9Ck4RvdR_BjlFnfTmg3LNSdWBUih3Tx_KvBK-LXe4pJMn5HuttsNnayF26e2qwvPjo5dWnnnWa4k3O8gbh_YYdzkE0j5DAk=)
+
+This allows a set of specific information to be available in each Standard, and:
+
+- Gives us the opportunity to track the catalogue status events that an entry goes through, such as _In Review_ to _Endorsed_, without it being tracked as a set of fields in the `Standard` itself
+- We decided that `specification_*` information would sit within the `Standard`, as it was very unlikely that we would produce multiple `Standard`s that had the same `specification`
+- License categorisation was added to make it clearer to the consumers of the site whether the licensing of the standard is Open/Proprietary, with the option to also add Unknown for cases where it is difficult to tell
+
+<details>
+
+<summary>Entity Relationship Diagram (raw)</summary>
+
+```erd
+[Standard]
+*identifier
+name { label: "string, required" }
+contraction { label: "string, required" }
+specification_url { label: "url, required" }
+description { label: "markdown" }
++tag_id
++licence_id
++maintainer_id
+
+[Event]
++standard_id
++status_id
+date {label: "required, date"}
+
+[Status]
+*identifier
+name { label: "string, required" }
+description
+
+[Tag]
+*identifier
+name { label: "string, required" }
+description
+
+[Licence]
+*identifier {label: "string, required"}
+name {label: "string, required"}
+type {label: "enum[OPEN,PROPRIETARY,UNKNOWN]"}
+url {label: "url"}
+
+[Organisation]
+*identifier
+name {label: "string, required"}
+url {label: "url, required"}
+
+Standard 1--* Standard
+Standard 1--+ Tag
+Standard 1--1 Licence
+Standard 1--1 Organisation
+Standard 1--+ Event
+Event 1--1 Status
+```
+
+</details>
+
+## Consequences
+
+No consequences at this time.

--- a/adr/0002-standards-static-site-configuration.md
+++ b/adr/0002-standards-static-site-configuration.md
@@ -1,0 +1,32 @@
+---
+creation_date: 2021-11-11
+decision_date: 2021-11-11
+status: accepted
+---
+# Alignment with the schema, while using a static website
+
+## Context
+
+This is a byproduct from ADR-0001, please review it for further context.
+
+As the DSA Workbench is a static site, with the Standards information being contributed through Markdown files with YAML frontmatter, we have a decision around how aligned we want to be with the planned schema.
+
+Because we have a mix of technical skills that are contributing to the repository, we need to balance schema adoption with ease of contribution.
+
+Schema adoption could mean that we use different data files for each data store, and treat the Standards themselves as purely machine-readable data.
+
+## Decision
+
+We have decided to prioritise the alignment with the schema, instead of reducing the number of files that need to be modified.
+
+This gives us the ability to start to align with the long-term data model before we migrate to using a full data store.
+
+## Consequences
+
+This will require a little more curation overhead, and as there will be a split across multiple files, there will be a little more work required by contributors to add/update standards.
+
+Some data, such as the `Events` data will for now be stored in the frontmatter, instead of separately.
+
+We will prioritise making sure contributing documentation is provided, and that support is provided to contributors to support them over time.
+
+We will continue to use Markdown with YAML frontmatter, as that is a fairly well understood format for contributors.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,19 @@
+---
+creation_date: 1970-01-01
+decision_date: null
+status: proposed|accepted|rejected|deprecated|superseded
+---
+
+# Title
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION

As we are defining the schema for the Standards portion of the
Workbench, we should make it clear that we've got an Architecture Design
Review (ADR) to capture this.

As we have discussed it offline, we are going straight to mark it as
`accepted`.

