### PR TITLE
Refactor `display_status` helper to reduce code duplication

### DIFF
--- a/content/guidance/index.html.md.erb
+++ b/content/guidance/index.html.md.erb
@@ -20,7 +20,7 @@ These pieces of guidance are in development by the Data Standards Authority. We 
         <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("guidance/") %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:guidance, f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/guidance/index.html.md.erb
+++ b/content/guidance/index.html.md.erb
@@ -20,7 +20,7 @@ These pieces of guidance are in development by the Data Standards Authority. We 
         <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("guidance/") %> </td>
-              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
+              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -25,7 +25,7 @@ The Data Standards Catalogue currently contains the following Standards:
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:standard, f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -25,7 +25,7 @@ The Data Standards Catalogue currently contains the following Standards:
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
               <td class="govuk-table__cell"><%= f.data.classification %> </td>
-              <td class="govuk-table__cell"><span class=<%= data.statuses[f.data.status].styling %>><%= display_status(f.data.status) %></span></td>
+              <td class="govuk-table__cell"><%= display_status(f.data.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -83,7 +83,8 @@ helpers do
 
   def display_status(id)
     if data.statuses[id]
-      data.statuses[id].name
+      status = data.statuses[id]
+      "<span class=#{status.styling}>#{status.name}</span>"
     else
       id
     end

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -81,9 +81,9 @@ helpers do
     end
   end
 
-  def display_status(id)
-    if data.statuses[id]
-      status = data.statuses[id]
+  def display_status(type, id)
+    if data.statuses[type] && data.statuses[type][id]
+      status = data.statuses[type][id]
       "<span class=#{status.styling}>#{status.name}</span>"
     else
       id

--- a/standards-catalogue/data/statuses.yml
+++ b/standards-catalogue/data/statuses.yml
@@ -1,12 +1,14 @@
-active:
-  name: Endorsed
-  styling: status-active
-draft:
-  name: Draft
-  styling: status-draft
-review:
-  name: In review
-  styling: status-draft
-published:
-  name: Published
-  styling: status-active
+standard:
+  active:
+    name: Endorsed
+    styling: status-active
+  review:
+    name: In review
+    styling: status-draft
+guidance:
+  draft:
+    name: Draft
+    styling: status-draft
+  published:
+    name: Published
+    styling: status-active

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -15,7 +15,7 @@
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
           <% elsif key == 'status' %>
-            <td nowrap><strong><%= display_status(value) %></strong> </td>
+            <td nowrap><strong><%= display_status(:standard, value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -15,7 +15,7 @@
           <% elsif key == 'organisation' %>
             <td nowrap><strong><%= display_organisation(value) %></strong> </td>
           <% elsif key == 'status' %>
-            <td nowrap><strong class=<%= data.statuses[value].styling %>><%= display_status(value) %></strong> </td>
+            <td nowrap><strong><%= display_status(value) %></strong> </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>


### PR DESCRIPTION
- Return CSS'd endorsement status from `display_status`
- Split endorsement statuses into what they relate to
