### PR TITLE
Use `endorsed` status for active standards

### DIFF
--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -8,7 +8,7 @@ name: UK Gemini
 supersededBy: 2.3
 organisation: Geospatial Commission
 validFrom: Jun-18
-status: active
+status: endorsed
 startDate: 2020-12-01
 dateAdded: 2020-12-16
 dateUpdated: 2020-12-16

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -7,7 +7,7 @@ link: https://www.gov.uk/government/publications/open-standards-for-government/i
 keywords: Identification, geospatial
 isRelatedTo: BS 7666-2:2006
 validFrom: 2020-07-1
-status: active
+status: endorsed
 dateAdded: 2020-12-16
 dateUpdated: 2020-12-16
 classification: Common Reference Data

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -6,7 +6,7 @@ subject: OpenDocuments (ODF)
 reference:	ODF 1.2
 name: ODF 1.2
 keywords: "OpenDocuments"
-status: active
+status: endorsed
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
 classification: Data, Information and Records Management Lifecycle

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -7,7 +7,7 @@ organisation: ietf
 reference:	RFC 4180
 name: RFC 4180 Common Format and MIME Type for Comma-Separated Values (CSV) Files
 keywords: "OpenDocuments"
-status: active
+status: endorsed
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
 classification: Data, Information and Records Management Lifecycle

--- a/standards-catalogue/data/statuses.yml
+++ b/standards-catalogue/data/statuses.yml
@@ -1,5 +1,5 @@
 standard:
-  active:
+  endorsed:
     name: Endorsed
     styling: status-active
   review:


### PR DESCRIPTION
As per an offline conversation with Arnau, the correct term here is
`endorsed`, rather than `active`.

This changes the identifier for the status, and leaves the CSS name, as
that's also used by the `guidance.published` status.
