### PR TITLE
Add tags data file

### DIFF
--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -1,14 +1,13 @@
 ---
 title: 360Giving Schema
-category: Domain Specific
-topic:	5.7 Grants, Loans & Subsidies
-subject: Payments Clearing and Settlement
+tags:
+- domain-specific
+- payments
 organisation: three-sixty-giving
 name: 360Giving Schema
 status: review
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
-classification: Domain Specific
 licence_id: CC-BY-4.0
 ---
 

--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -1,6 +1,8 @@
 ---
 title: UK Gemini
-keywords: Semantics
+tags:
+- semantics
+- metadata
 identifier: UK-123
 link: https://www.agi.org.uk/agi-groups/standards-committee/uk-gemini
 isRelatedTo: ISO 19139
@@ -12,7 +14,6 @@ status: endorsed
 startDate: 2020-12-01
 dateAdded: 2020-12-16
 dateUpdated: 2020-12-16
-classification: Metadata
 licence_id: CC-BY-4.0
 ---
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -1,16 +1,18 @@
 ---
 title: UPRN
+tags:
+- identification
+- geospatial
+- common-reference-data
 name: UPRN
 organisation: ordnance-survey
 identifier: UKABC-123
 link: https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information
-keywords: Identification, geospatial
 isRelatedTo: BS 7666-2:2006
 validFrom: 2020-07-1
 status: endorsed
 dateAdded: 2020-12-16
 dateUpdated: 2020-12-16
-classification: Common Reference Data
 licence_id: OGL-UK-3.0
 ---
 

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -15,7 +15,6 @@ The Data Standards Catalogue currently contains the following Standards:
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Name</th>
-        <th scope="col" class="govuk-table__header">Classification</th>
         <th scope="col" class="govuk-table__header">Status</th>
       </tr>
     </thead>
@@ -24,7 +23,6 @@ The Data Standards Catalogue currently contains the following Standards:
       <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
-              <td class="govuk-table__cell"><%= f.data.classification %> </td>
               <td class="govuk-table__cell"><%= display_status(:standard, f.data.status) %></td>
             </tr>
         <% end %>

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -1,8 +1,8 @@
 ---
 title: Universal financial industry message scheme
-category: Domain Specific
-topic: 5.5 Payment
-subject: Payments Clearing and Settlement
+tags:
+- domain-specific
+- payments
 organisation: iso
 reference:	ISO 20022
 identifier:	pacs
@@ -10,7 +10,6 @@ name: Universal financial industry message scheme
 status: review
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
-classification: Domain Specific
 licence_id: proprietary
 ---
 

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -1,16 +1,14 @@
 ---
 title: ODF 1.2
-category: Data, Information and Records Management Lifecycle
-topic: 4.7 Content Management
-subject: OpenDocuments (ODF)
+tags:
+- data-info-and-records-management
+- open-documents
 organisation: odf
 reference:	ODF 1.2
 name: ODF 1.2
-keywords: "OpenDocuments"
 status: endorsed
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
-classification: Data, Information and Records Management Lifecycle
 licence_id: unknown
 ---
 

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -1,14 +1,15 @@
 ---
 title: OpenReferralUK
+tags:
+- service-referrals
+- service-design
 name: OpenReferralUK
 organisation: open-referral-uk
-keywords: "Service Referrals"
 identifier: UK123-ZXY
 link: https://openreferraluk.org/
 status: review
 dateAdded: 2020-12-16
 dateUpdated: 2021-07-05
-classification: Service, Product, Application, System or Platform Design
 licence_id: CC-BY-SA-4.0
 ---
 

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -1,16 +1,15 @@
 ---
 title: Common Format and MIME Type for Comma-Separated Values (CSV) Files
-category: Data, Information and Records Management Lifecycle
-topic: 4.7 Content Management
-subject: Tabular Data
+tags:
+- tabular-data
+- data-info-and-records-management
+- open-documents
 organisation: ietf
 reference:	RFC 4180
 name: RFC 4180 Common Format and MIME Type for Comma-Separated Values (CSV) Files
-keywords: "OpenDocuments"
 status: endorsed
 dateAdded: 2021-02-02
 dateUpdated: 2021-02-02
-classification: Data, Information and Records Management Lifecycle
 license_id: unknown
 ---
 

--- a/standards-catalogue/.schema/licence.json
+++ b/standards-catalogue/.schema/licence.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://github.com/alphagov/data-standards-authority/blob/main/standards-catalogue/.schema/licences.json",
+  "id": "https://github.com/alphagov/data-standards-authority/blob/main/standards-catalogue/.schema/licence.json",
   "title": "Data Standards Authority Licences objects",
   "description": "A JSON Schema to manage the format of licence objects",
   "type": "object",

--- a/standards-catalogue/.schema/tag.json
+++ b/standards-catalogue/.schema/tag.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://github.com/alphagov/data-standards-authority/blob/main/standards-catalogue/.schema/tag.json",
+  "title": "Data Standards Authority Tag objects",
+  "description": "A JSON Schema to manage the format of tag objects",
+  "type": "object",
+  "required": [
+    "name"
+  ],
+  "properties": {
+    "name": {
+      "$comment": "The name of the tag",
+      "type": "string",
+      "minLength": 2
+    },
+    "description": {
+      "$comment": "A description of the tag",
+      "type": "string"
+    }
+  }
+}

--- a/standards-catalogue/Rakefile
+++ b/standards-catalogue/Rakefile
@@ -68,9 +68,19 @@ namespace :schema do
       end
       raise unless errors.all?
     end
+
+    desc "Validate tags are schema compliant"
+    task :tags do
+      schema = schema("tag")
+      tags = YAML.load_file("data/tags.yml")
+      errors = tags.map do |_, tag|
+        is_valid_schema(schema, tag)
+      end
+      raise unless errors.all?
+    end
   end
 
-  task data_files: %w[data_files:sync_standards_status data_files:organisations data_files:licences]
+  task data_files: %w[data_files:sync_standards_status data_files:organisations data_files:licences data_files:tags]
 
   desc "Validate Standards are schema compliant"
   task :standards do

--- a/standards-catalogue/Rakefile
+++ b/standards-catalogue/Rakefile
@@ -26,6 +26,15 @@ def is_valid_schema(schema, to_validate)
   false
 end
 
+def is_data_file_schema_compliant(schema, to_validate)
+  schema = schema(schema)
+  objects = YAML.load_file(to_validate)
+  errors = objects.map do |_, object|
+    is_valid_schema(schema, object)
+  end
+  raise unless errors.all?
+end
+
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
@@ -51,32 +60,17 @@ namespace :schema do
 
     desc "Validate organisations are schema compliant"
     task :organisations do
-      schema = schema("organisation")
-      organisations = YAML.load_file("data/organisations.yml")
-      errors = organisations.map do |_, organisation|
-        is_valid_schema(schema, organisation)
-      end
-      raise unless errors.all?
+      is_data_file_schema_compliant("organisation", "data/organisations.yml")
     end
 
     desc "Validate licences are schema compliant"
     task :licences do
-      schema = schema("licence")
-      licences = YAML.load_file("data/licences.yml")
-      errors = licences.map do |_, licence|
-        is_valid_schema(schema, licence)
-      end
-      raise unless errors.all?
+      is_data_file_schema_compliant("licence", "data/licences.yml")
     end
 
     desc "Validate tags are schema compliant"
     task :tags do
-      schema = schema("tag")
-      tags = YAML.load_file("data/tags.yml")
-      errors = tags.map do |_, tag|
-        is_valid_schema(schema, tag)
-      end
-      raise unless errors.all?
+      is_data_file_schema_compliant("tag", "data/tags.yml")
     end
   end
 

--- a/standards-catalogue/data/tags.yml
+++ b/standards-catalogue/data/tags.yml
@@ -1,0 +1,24 @@
+domain-specific:
+  name: Domain Specific
+payments:
+  name: Payments Clearing and Settlement
+metadata:
+  name: Metadata
+semantics:
+  name: Semantics
+identification:
+  name: Identification
+geopsatial:
+  name: Geospatial
+common-reference-data:
+  name: Common Reference Data
+data-info-and-records-management:
+  name: Data, Information and Records Management Lifecycle
+open-documents:
+  name: Open Documents
+service-referrals:
+  name: Service Referrals
+tabular-data:
+  name: Tabular Data
+service-design:
+  name: Service, Product, Application, System or Platform Design

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -18,6 +18,14 @@
             <td nowrap><strong><%= display_status(:standard, value) %></strong> </td>
           <% elsif key == 'licence_id' %>
             <%= display_licence(value) %>
+          <% elsif key == 'tags' %>
+            <td nowrap>
+              <ul>
+                <% current_page.data.tags.each do |tag| %>
+                  <li><strong><%= tag %></strong></li>
+                <% end %>
+              </ul>
+            </td>
           <% else %>
             <td nowrap><strong><%= value %></strong> </td>
           <% end %>


### PR DESCRIPTION
- Add a data file for tags to reduce duplication 
- I've added a description to the json schema as we have it in our [data structure](https://github.com/alphagov/data-standards-authority/blob/main/adr/0001-standards-catalogue-data-structure.md), but haven't added any descriptions - I've used what was in the topics, keywords and classifications as the tags and I think we can change those / add descriptions in a separate PR