### PR TITLE
Add schema content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Lint
         run: bundle exec rubocop --parallel
 
+      - name: Validate files are schema compliant
+        run: bundle exec rake schema
+
       - name: Build
         run: bundle exec rake build
 

--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -9,7 +9,7 @@ maintainer_id: three-sixty-giving
 licence_id: CC-BY-4.0
 endorsement_status_events:
 - status: review
-  date: '2021-02-02'
+  date: "2021-02-02"
 ---
 
 

--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -1,14 +1,15 @@
 ---
-title: 360Giving Schema
+name: 360Giving Schema
+contraction: 360GS
+specification_url: https://standard.threesixtygiving.org/en/latest/reference/#spreadsheet-format
 tags:
 - domain-specific
 - payments
-organisation: three-sixty-giving
-name: 360Giving Schema
-status: review
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
+maintainer_id: three-sixty-giving
 licence_id: CC-BY-4.0
+endorsement_status_events:
+- status: review
+  date: '2021-02-02'
 ---
 
 

--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -9,7 +9,7 @@ maintainer_id: geospatial-commission
 licence_id: CC-BY-4.0
 endorsement_status_events:
 - status: endorsed
-  date: '2020-12-01'
+  date: "2020-12-01"
 ---
 
 

--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -1,20 +1,15 @@
 ---
-title: UK Gemini
+name: UK Gemini
+contraction: GEMINI
+specification_url: https://www.agi.org.uk/gemini/40-gemini/1037-uk-gemini-standard-and-inspire-implementing-rules/
 tags:
 - semantics
 - metadata
-identifier: UK-123
-link: https://www.agi.org.uk/agi-groups/standards-committee/uk-gemini
-isRelatedTo: ISO 19139
-name: UK Gemini
-supersededBy: 2.3
-organisation: geospatial-commission
-validFrom: Jun-18
-status: endorsed
-startDate: 2020-12-01
-dateAdded: 2020-12-16
-dateUpdated: 2020-12-16
+maintainer_id: geospatial-commission 
 licence_id: CC-BY-4.0
+endorsement_status_events:
+- status: endorsed
+  date: '2020-12-01'
 ---
 
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -1,19 +1,16 @@
 ---
-title: UPRN
+name: Unique Property Reference Number
+contraction: UPRN
+specification_url: https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information
 tags:
 - identification
 - geospatial
 - common-reference-data
-name: UPRN
-organisation: ordnance-survey
-identifier: UKABC-123
-link: https://www.gov.uk/government/publications/open-standards-for-government/identifying-property-and-street-information
-isRelatedTo: BS 7666-2:2006
-validFrom: 2020-07-1
-status: endorsed
-dateAdded: 2020-12-16
-dateUpdated: 2020-12-16
+maintainer_id: ordnance-survey
 licence_id: OGL-UK-3.0
+endorsement_status_events:
+- status: endorsed
+  date: '2020-12-16'
 ---
 
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -10,7 +10,7 @@ maintainer_id: ordnance-survey
 licence_id: OGL-UK-3.0
 endorsement_status_events:
 - status: endorsed
-  date: '2020-12-16'
+  date: "2020-12-16"
 ---
 
 

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -23,7 +23,7 @@ The Data Standards Catalogue currently contains the following Standards:
       <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
-              <td class="govuk-table__cell"><%= display_status(:standard, f.data.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:standard, f.data.endorsement_status_events.last.status) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -1,16 +1,15 @@
 ---
-title: Universal financial industry message scheme
+name: Universal financial industry message scheme
+contraction: ISO20022
+specification_url: https://www.iso20022.org/iso-20022-message-definitions
 tags:
 - domain-specific
 - payments
-organisation: iso
-reference:	ISO 20022
-identifier:	pacs
-name: Universal financial industry message scheme
-status: review
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
+maintainer_id: iso
 licence_id: proprietary
+endorsement_status_events:
+- status: review
+  date: '2021-02-02'
 ---
 
 

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -9,7 +9,7 @@ maintainer_id: iso
 licence_id: proprietary
 endorsement_status_events:
 - status: review
-  date: '2021-02-02'
+  date: "2021-02-02"
 ---
 
 

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -1,15 +1,15 @@
 ---
-title: ODF 1.2
+name: ODF 1.2
+contraction: ODF1.2
+specification_url: https://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.html
 tags:
 - data-info-and-records-management
 - open-documents
-organisation: odf
-reference:	ODF 1.2
-name: ODF 1.2
-status: endorsed
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
+maintainer_id: odf 
 licence_id: unknown
+endorsement_status_events: 
+- status: endorsed 
+  date: '2021-02-02'
 ---
 
 

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -9,7 +9,7 @@ maintainer_id: odf
 licence_id: unknown
 endorsement_status_events: 
 - status: endorsed 
-  date: '2021-02-02'
+  date: "2021-02-02"
 ---
 
 

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -1,16 +1,15 @@
 ---
-title: OpenReferralUK
+name: OpenReferralUK
+contraction: ORUK
+specification_url: https://openreferraluk.org/about-standard
 tags:
 - service-referrals
 - service-design
-name: OpenReferralUK
-organisation: open-referral-uk
-identifier: UK123-ZXY
-link: https://openreferraluk.org/
-status: review
-dateAdded: 2020-12-16
-dateUpdated: 2021-07-05
+maintainer_id: open-referral-uk 
 licence_id: CC-BY-SA-4.0
+endorsement_status_events:
+- status: review
+  date: '2020-12-16'
 ---
 
 

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -9,7 +9,7 @@ maintainer_id: open-referral-uk
 licence_id: CC-BY-SA-4.0
 endorsement_status_events:
 - status: review
-  date: '2020-12-16'
+  date: "2020-12-16"
 ---
 
 

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -1,16 +1,16 @@
 ---
-title: Common Format and MIME Type for Comma-Separated Values (CSV) Files
+name: Common Format and MIME Type for Comma-Separated Values (CSV) Files
+contraction: RFC4180
+specification_url: https://tools.ietf.org/html/rfc4180
 tags:
 - tabular-data
 - data-info-and-records-management
 - open-documents
-organisation: ietf
-reference:	RFC 4180
-name: RFC 4180 Common Format and MIME Type for Comma-Separated Values (CSV) Files
-status: endorsed
-dateAdded: 2021-02-02
-dateUpdated: 2021-02-02
-license_id: unknown
+maintainer_id: ietf 
+licence_id: unknown
+endorsement_status_events:
+- status: endorsed
+  date: '2021-02-02'
 ---
 
 

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -10,7 +10,7 @@ maintainer_id: ietf
 licence_id: unknown
 endorsement_status_events:
 - status: endorsed
-  date: '2021-02-02'
+  date: "2021-02-02"
 ---
 
 

--- a/standards-catalogue/.schema/standards.json
+++ b/standards-catalogue/.schema/standards.json
@@ -11,7 +11,7 @@
     "maintainer_id",
     "endorsement_status_events",
     "tags",
-    "license_id"
+    "licence_id"
   ],
   "properties": {
     "identifier": {
@@ -41,7 +41,7 @@
       "$comment": "The events that this standard's status has been through",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/endorsement_status_events"
+        "$ref": "#/definitions/endorsement_status_event"
       }
     },
     "tags": {
@@ -56,7 +56,7 @@
       "$comment": "The long-form description of the standard, for instance written using Markdown",
       "type": "string"
     },
-    "license_id": {
+    "licence_id": {
       "$comment": "A Software Package Data Exchange (SPDX) license identifier, if applicable, or `Proprietary` / `Unknown`",
       "type": "string",
       "pattern": "(Proprietary|Unknown|.+)",

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -93,9 +93,9 @@ helpers do
   def display_licence(id)
     licence = data.licences[id]
     if licence.url
-      "<td nowrap><strong>#{licence.type} - <a href=#{licence.url}>#{licence.name}</a></strong></td>"
+      "<strong>#{licence.type} - <a href=#{licence.url}>#{licence.name}</a></strong>"
     else
-      "<td nowrap><strong>#{licence.name}</strong></td>"
+      "<strong>#{licence.name}</strong>"
     end
   end
 

--- a/standards-catalogue/data/tags.yml
+++ b/standards-catalogue/data/tags.yml
@@ -8,7 +8,7 @@ semantics:
   name: Semantics
 identification:
   name: Identification
-geopsatial:
+geospatial:
   name: Geospatial
 common-reference-data:
   name: Common Reference Data

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -1,36 +1,52 @@
 <% wrap_layout :layout do %>
 
   <div style = "overflow-x:auto;">
-    <% if !current_page.data.title.nil? %>
-      <h1><%= current_page.data.title %></h1>
-    <% else %>
-      <h1><%= current_page.data.name %></h1>
-    <% end %>
+    <h1><%= current_page.data.name %></h1>
     <table style="width:100%">
-      <% current_page.data.each do |key, value| %>
-        <tr>
-          <td nowrap><%= key.titleize.capitalize %>: </td>
-          <% if key == 'link' %>
-            <td nowrap><strong><a href='<%= value %>'><%= value %></a></strong> </td>
-          <% elsif key == 'organisation' %>
-            <td nowrap><strong><%= display_organisation(value) %></strong> </td>
-          <% elsif key == 'status' %>
-            <td nowrap><strong><%= display_status(:standard, value) %></strong> </td>
-          <% elsif key == 'licence_id' %>
-            <%= display_licence(value) %>
-          <% elsif key == 'tags' %>
-            <td nowrap>
-              <ul>
-                <% current_page.data.tags.each do |tag| %>
-                  <li><strong><%= tag %></strong></li>
-                <% end %>
-              </ul>
-            </td>
-          <% else %>
-            <td nowrap><strong><%= value %></strong> </td>
-          <% end %>
-        </tr>
-      <% end %>
+      <tr>
+        <td>Name</td>
+        <td>
+          <strong><%=link_to current_page.data.name, current_page.data.specification_url %></strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Also Known As</td>
+        <td>
+          <strong><%= current_page.data.contraction %></strong>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Tags</td>
+        <td>
+          <ul>
+            <% current_page.data.tags.each do |tag| %>
+              <li><strong><%= data.tags[tag].name %></strong></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Maintained By</td>
+        <td><strong><%= display_organisation(current_page.data.maintainer_id) %></strong> </td>
+      </tr>
+
+      <tr>
+        <td>Licence</td>
+        <td>
+          <%= display_licence(current_page.data.licence_id) %>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Status</td>
+        <td>
+          <% status = current_page.data.endorsement_status_events.last.status %>
+          <strong><%= display_status(:standard, status) %></strong>
+        </td>
+      </tr>
     </table>
   </div>
 

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -30,7 +30,7 @@
 
       <tr>
         <td>Maintained By</td>
-        <td><strong><%= display_organisation(current_page.data.maintainer_id) %></strong> </td>
+        <td><strong><%= display_organisation(current_page.data.maintainer_id) %></strong></td>
       </tr>
 
       <tr>

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -20,7 +20,7 @@
       <tr>
         <td>Tags</td>
         <td>
-          <ul>
+          <ul class="list-of-tags">
             <% current_page.data.tags.each do |tag| %>
               <li><strong><%= data.tags[tag].name %></strong></li>
             <% end %>

--- a/standards-catalogue/source/stylesheets/_core.scss
+++ b/standards-catalogue/source/stylesheets/_core.scss
@@ -10,3 +10,4 @@
 @import "modules/collapsible";
 @import "modules/navbar";
 @import "modules/status";
+@import "modules/standards-table";

--- a/standards-catalogue/source/stylesheets/modules/_standards-table.scss
+++ b/standards-catalogue/source/stylesheets/modules/_standards-table.scss
@@ -1,0 +1,3 @@
+.list-of-tags {
+  padding-left: 20px;
+}


### PR DESCRIPTION
We've created a [schema](https://github.com/alphagov/data-standards-authority/blob/main/adr/0001-standards-catalogue-data-structure.md) as part of our plans to introduce schema.org metata for the standards section, and the content in each of the standards should now match it.