### PR TITLE
Be stricter on maintainer_id being present

### DIFF
--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -77,7 +77,7 @@ helpers do
     if data.organisations[id]
       link_to data.organisations[id].name, data.organisations[id].url
     else
-      id
+      raise "maintainer_id must match an entry in organisations.yml"
     end
   end
 


### PR DESCRIPTION
If it's not present now, the rake build task will fail.

Closes https://github.com/alphagov/data-standards-authority/issues/131