### PR TITLE
Produce schema.org metadata on standards pages

### DIFF
--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -7,6 +7,7 @@ require "middleman-search"
 
 require "active_support/all"
 
+require "lib/schemaorg"
 require "lib/govuk_tech_docs/contribution_banner"
 require "lib/govuk_tech_docs/meta_tags"
 require "lib/govuk_tech_docs/tech_docs_html_renderer"
@@ -56,6 +57,7 @@ activate :unique_identifier
 
 helpers do
   include GovukTechDocs::ContributionBanner
+  include SchemaOrg
 
   def meta_tags
     @meta_tags ||= GovukTechDocs::MetaTags.new(config, current_page)
@@ -107,6 +109,10 @@ helpers do
     else
       page.path.delete_prefix("standards/").chomp("/index.html")
     end
+  end
+
+  def standard_to_schemaorg(page_data)
+    SchemaOrg::Standard.new(data, page_data).to_json
   end
 end
 

--- a/standards-catalogue/lib/schemaorg.rb
+++ b/standards-catalogue/lib/schemaorg.rb
@@ -1,0 +1,84 @@
+module SchemaOrg
+  class Base
+    attr_accessor :obj
+
+    # Middleman uses ActiveSupport's JSON encoder, which requires `as_json` to produce the hash representation of the object
+    def as_json(_options = {})
+      @obj
+    end
+  end
+
+  class Standard < SchemaOrg::Base
+    def initialize(data, page_data)
+      super()
+
+      categories = categories(data, page_data)
+      licence_info = SchemaOrg::Licence.new(data, page_data.licence_id)
+      maintainer_info = SchemaOrg::Organisation.new(data, page_data.maintainer_id)
+      endorsement_status = page_data.endorsement_status_events.last.status
+      specification = SchemaOrg::Specification.new(page_data.name, page_data.specification_url)
+
+      @obj = {
+        "@context": "https://schema.org/",
+        "@type": "Thing",
+        "name": page_data.name,
+        "contraction": page_data.contraction,
+        "isBasedOn": specification,
+        "license": licence_info, # this needs to be US spelling
+        "category": categories,
+        "maintainer": maintainer_info,
+        "endorsementStatus": endorsement_status,
+      }
+    end
+
+  private
+
+    def categories(data, page_data)
+      page_data.tags.map do |tag|
+        data.tags[tag].name
+      end
+    end
+  end
+
+  class Organisation < SchemaOrg::Base
+    def initialize(data, organisation_id)
+      super()
+
+      organisation = data.organisations[organisation_id]
+
+      @obj = {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": organisation.name,
+        "url": organisation.url,
+      }
+    end
+  end
+
+  class Licence < SchemaOrg::Base
+    def initialize(data, licence_id)
+      super()
+
+      licence = data.licences[licence_id]
+      @obj = {
+        "@context": "https://schema.org",
+        "@type": "CreativeWork",
+        "name": licence.name,
+      }
+      @obj["url"] = licence.url if licence.url
+    end
+  end
+
+  class Specification < SchemaOrg::Base
+    def initialize(name, specification_url)
+      super()
+
+      @obj = {
+        "@context": "https://schema.org",
+        "@type": "CreativeWork",
+        "name": name,
+        "url": specification_url,
+      }
+    end
+  end
+end

--- a/standards-catalogue/source/layouts/standards_table.erb
+++ b/standards-catalogue/source/layouts/standards_table.erb
@@ -52,4 +52,8 @@
 
   <%= yield %>
 
+  <script type="application/ld+json">
+    <%= standard_to_schemaorg(current_page.data) %>
+  </script>
+
 <% end %>


### PR DESCRIPTION
As well as producing human-readable standards, we should be producing
machine-readable metadata for automagic consumption of the standards
we're producing.

As the standard across Government is schema.org, we need to produce
schema.org metadata.

To simplify the logic for generating this data, we can create Ruby
classes per entity, and store the schema.org representation internally.
Using classes allows us to centrally set up the classes with a base
class, as well as - in the future - allow for unit testing of these
isolated components.

Due to the way that Middleman currently uses ActiveSupport's JSON
encoder, we need to make sure that we implement `as_json` to allow
nesting our objects more nicely and allow them to be JSON encoded
without a problem.
