### PR TITLE
Amend GitHub Actions configuration for read-only permissions by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,17 +57,39 @@ jobs:
       - name: Build
         run: bundle exec rake build
 
+      - name: Upload built site
+        uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: build
+          retention-days: 1
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Download built site
+        uses: actions/download-artifact@v2
+        with:
+          name: site
+          path: build
+
       # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
       - name: Checkout gh-pages branch
-        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/checkout@v2
         with:
           ref: gh-pages
           path: tmp/publish
 
       - name: Publish
-        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git config --global user.email "github-actions@github.com"
           git config --global user.name "github-actions"
-          bundle exec rake publish CLONED_GH_PAGES_DIR="../tmp/publish"
+          bundle exec rake publish CLONED_GH_PAGES_DIR="tmp/publish"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: standards-catalogue
@@ -68,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: build
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
- Split build and publish functionality into jobs
- Add explicit `permissions` settings (as required by Org-wide changes)

Pulls changes from https://github.com/alphagov/api-catalogue/pull/287, https://github.com/alphagov/api-catalogue/pull/288,  https://github.com/alphagov/api-catalogue/pull/289
