### PR TITLE
Fix: Follow-ups for new Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: site
-          path: build
+          path: standards-catalogue/build
           retention-days: 1
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          ruby-version: 2.7
+          working-directory: standards-catalogue
 
       - name: Download built site
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: site
-          path: build
+          path: built-site
+
+      - name: 'Prepare directory structure for `rake publish`'
+        run: mv built-site/standards-catalogue build
 
       # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
       - name: Checkout gh-pages branch


### PR DESCRIPTION
- Fix: Use correct location for built site to be uploaded/downloaded
- Fix: Use correct `working-directory` for `setup-ruby`
- Fix: Handle nested publish directory hierarchy
