### PR TITLE
Revert "Fix: Handle nested publish directory hierarchy"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: site
-          path: built-site
-
-      - name: 'Prepare directory structure for `rake publish`'
-        run: mv built-site/standards-catalogue build
+          path: build
 
       # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
       - name: Checkout gh-pages branch


### PR DESCRIPTION
This may not actually be the case, so we can revert this.

This reverts commit 201237fac6947c7aa9c2fa7867b915bf5e988b77.
