### PR TITLE
Fix: Use subdirectory for publish process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
     needs: build
     permissions:
       contents: write
+    defaults:
+      run:
+        working-directory: standards-catalogue
     steps:
       - uses: actions/checkout@v2
 
@@ -85,7 +88,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: site
-          path: build
+          path: standards-catalogue/build
 
       # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
       - name: Checkout gh-pages branch
@@ -98,4 +101,4 @@ jobs:
         run: |
           git config --global user.email "github-actions@github.com"
           git config --global user.name "github-actions"
-          bundle exec rake publish CLONED_GH_PAGES_DIR="tmp/publish"
+          bundle exec rake publish CLONED_GH_PAGES_DIR="../tmp/publish"


### PR DESCRIPTION
As we're expecting to run `rake` from our `standards-catalogue`
directory, as well as have the `Gemfile` present, we should just
continue to use the subdirectory for the purpose of the publish process,
rather than trying to work around it.
