### PR TITLE
Include short description, tags and date updated in contents

### DIFF
--- a/content/standards/360giving/index.html.md
+++ b/content/standards/360giving/index.html.md
@@ -9,6 +9,7 @@ licence_id: CC-BY-4.0
 endorsement_status_events:
 - status: review
   date: "2021-02-02"
+short_description:
 ---
 
 

--- a/content/standards/UKGemini/index.html.md
+++ b/content/standards/UKGemini/index.html.md
@@ -10,6 +10,7 @@ licence_id: CC-BY-4.0
 endorsement_status_events:
 - status: review
   date: "2020-12-01"
+short_description:
 ---
 
 

--- a/content/standards/UPRN/index.html.md
+++ b/content/standards/UPRN/index.html.md
@@ -11,6 +11,7 @@ licence_id: OGL-UK-3.0
 endorsement_status_events:
 - status: endorsed
   date: "2020-12-16"
+short_description:
 ---
 
 

--- a/content/standards/bods/index.html.md
+++ b/content/standards/bods/index.html.md
@@ -9,6 +9,7 @@ licence_id: Apache-2.0
 endorsement_status_events:
 - status: endorsed
   date: "2022-04-22"
+short_description:
 ---
 
 

--- a/content/standards/index.html.md.erb
+++ b/content/standards/index.html.md.erb
@@ -15,15 +15,29 @@ The Data Standards Catalogue currently contains the following Standards:
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Name</th>
+        <th scope="col" class="govuk-table__header">Tags</th>
         <th scope="col" class="govuk-table__header">Status</th>
+        <th scope="col" class="govuk-table__header">Date updated</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <% current_resource.children.reject{|page| page.data.exclude_from_list}.sort_by{ |page| get_link_text(page).downcase }.each do |f| %>
-      <% if f.content_type.include? "html" %>
+        <% if f.content_type.include? "html" %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= link_to get_link_text(f), f.path.delete_prefix("standards/") %> </td>
+              <td class="govuk-table__cell">
+                  <%= link_to get_link_text(f), f.path.delete_prefix("standards/") %>
+                  <br><br>
+                  <%= f.data.short_description %>
+              </td>
+              <td class="govuk-table__cell">
+                  <ul>
+                        <% f.data.tags.each do |g| %>
+                              <li><%= display_tags(g) %></li>
+                        <% end %>
+                  </ul>
+              </td>
               <td class="govuk-table__cell"><%= display_status(:standard, f.data.endorsement_status_events.last.status) %></td>
+              <td class="govuk-table__cell"><%= display_status(:standard, f.data.endorsement_status_events.last.date) %></td>
             </tr>
         <% end %>
       <% end %>

--- a/content/standards/iso20022/index.html.md
+++ b/content/standards/iso20022/index.html.md
@@ -10,6 +10,7 @@ licence_id: proprietary
 endorsement_status_events:
 - status: review
   date: "2021-02-02"
+short_description:
 ---
 
 

--- a/content/standards/odf12/index.html.md
+++ b/content/standards/odf12/index.html.md
@@ -9,6 +9,7 @@ licence_id: unknown
 endorsement_status_events: 
 - status: endorsed 
   date: "2021-02-02"
+short_description:
 ---
 
 

--- a/content/standards/openreferraluk/index.html.md
+++ b/content/standards/openreferraluk/index.html.md
@@ -9,6 +9,7 @@ licence_id: CC-BY-SA-4.0
 endorsement_status_events:
 - status: review
   date: "2020-12-16"
+short_description:
 ---
 
 

--- a/content/standards/rfc4180/index.html.md
+++ b/content/standards/rfc4180/index.html.md
@@ -11,6 +11,7 @@ licence_id: unknown
 endorsement_status_events:
 - status: endorsed
   date: "2021-02-02"
+short_description:
 ---
 
 

--- a/standards-catalogue/.schema/standards.json
+++ b/standards-catalogue/.schema/standards.json
@@ -10,7 +10,8 @@
     "maintainer_id",
     "endorsement_status_events",
     "tags",
-    "licence_id"
+    "licence_id",
+    "short_description"
   ],
   "properties": {
     "identifier": {
@@ -60,6 +61,11 @@
       "$comment": "A Software Package Data Exchange (SPDX) license identifier, if applicable, or `Proprietary` / `Unknown`",
       "type": "string",
       "pattern": "(Proprietary|Unknown|.+)",
+      "minLength": 1
+    },
+    "short_description": {
+      "$comment": "A short description one or two sentences long, giving an overview of the standard",
+      "type": ["string", "null"],
       "minLength": 1
     }
   },

--- a/standards-catalogue/config.rb
+++ b/standards-catalogue/config.rb
@@ -83,6 +83,14 @@ helpers do
     end
   end
 
+  def display_tags(id)
+    if data.tags[id]
+      data.tags[id].name
+    else
+      raise "tags must match an entry in tags.yml"
+    end
+  end
+
   def display_status(type, id)
     if data.statuses[type] && data.statuses[type][id]
       status = data.statuses[type][id]


### PR DESCRIPTION
This should make it clearer when people land on this page what the standards
are about and make it easier to find one that fits their needs.

If `short_description` is not provided in the front matter, it will just
display the name on the contents page rather than name and description.

How it looks:
![Screenshot 2022-04-25 at 14 37 59](https://user-images.githubusercontent.com/13121570/165103189-4fd4f7fd-ce21-4e8c-a148-c23a57532378.png)


How it will look when text is added to the short_description fields:


![Screenshot 2022-04-25 at 14 40 16](https://user-images.githubusercontent.com/13121570/165103215-5c7bbe11-fc70-4824-8b0a-c4fc40420258.png)

