### PR TITLE
Update Beneficial Ownership Data Standard to version 0.3

### DIFF
--- a/content/standards/bods/index.html.md
+++ b/content/standards/bods/index.html.md
@@ -1,6 +1,6 @@
 ---
-name: Beneficial Ownership Data Standard (BODS) v0.2
-specification_url: https://standard.openownership.org/en/0.2.0/about/index.html
+name: Beneficial Ownership Data Standard (BODS) v0.3
+specification_url: https://standard.openownership.org/en/0.3.0/about/index.html
 tags:
 - service-referrals
 - service-design


### PR DESCRIPTION
Change request:

> On the [standards catalogue](https://alphagov.github.io/data-standards-authority/standards/) could you please update the title of the [Beneficial Ownership Data Standard (BODS) v0.2 ](https://alphagov.github.io/data-standards-authority/standards/bods/)to reflect that it is version 0.3 rather tan 0.2? The hyperlink included under "name" should also be updated to the following: https://standard.openownership.org/en/0.3.0/about/index.html. On the description where it talks about the standard it would also need to be changed to 0.3 instead of 0.2 (as it is right now).